### PR TITLE
get go-dbus compiling on windows

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -546,13 +546,14 @@ type transport interface {
 	SendMessage(*Message) error
 }
 
+var (
+	transports map[string]func(string) (transport, error) = make(map[string]func(string) (transport, error))
+)
+
 func getTransport(address string) (transport, error) {
 	var err error
 	var t transport
 
-	m := map[string]func(string) (transport, error){
-		"unix": newUnixTransport,
-	}
 	addresses := strings.Split(address, ";")
 	for _, v := range addresses {
 		i := strings.IndexRune(v, ':')
@@ -560,7 +561,7 @@ func getTransport(address string) (transport, error) {
 			err = errors.New("dbus: invalid bus address (no transport)")
 			continue
 		}
-		f := m[v[:i]]
+		f := transports[v[:i]]
 		if f == nil {
 			err = errors.New("dbus: invalid bus address (invalid or unsupported transport)")
 		}

--- a/transport_unix.go
+++ b/transport_unix.go
@@ -1,3 +1,5 @@
+//+build !windows
+
 package dbus
 
 import (
@@ -56,6 +58,10 @@ func newUnixTransport(keys string) (transport, error) {
 	default:
 		return nil, errors.New("dbus: invalid address (both path and abstract set)")
 	}
+}
+
+func init() {
+	transports["unix"] = newUnixTransport
 }
 
 func (t *unixTransport) EnableUnixFDs() {

--- a/transport_unixcred.go
+++ b/transport_unixcred.go
@@ -1,4 +1,4 @@
-// +build !darwin
+// +build !darwin,!windows
 
 package dbus
 


### PR DESCRIPTION
This is for issue #2

rather than making a wrapper, it made more since to add conditional compilation and decouple connections from the unix transport.

I tested building this on my windows 8 machine and OSX 10.8 and also ran go test.

I admit both the original code and this just sits there when I run go test... but I got errors when I broke things and so I think this holds water.

Let me know if you need any other changes.
