### PR TITLE
Add UnixCredentials system call for DragonFly BSD

### DIFF
--- a/transport_unixcred_dragonfly.go
+++ b/transport_unixcred_dragonfly.go
@@ -1,6 +1,6 @@
 // The UnixCredentials system call is currently only implemented on Linux
 // http://golang.org/src/pkg/syscall/sockcmsg_linux.go
-// https://groups.google.com/forum/#!topic/golang-dev/z7VbyqR1s78
+// https://golang.org/s/go1.4-syscall
 // http://code.google.com/p/go/source/browse/unix/sockcmsg_linux.go?repo=sys
 
 // Local implementation of the UnixCredentials system call for DragonFly BSD

--- a/transport_unixcred_linux.go
+++ b/transport_unixcred_linux.go
@@ -1,6 +1,6 @@
 // The UnixCredentials system call is currently only implemented on Linux
 // http://golang.org/src/pkg/syscall/sockcmsg_linux.go
-// https://groups.google.com/forum/#!topic/golang-dev/z7VbyqR1s78
+// https://golang.org/s/go1.4-syscall
 // http://code.google.com/p/go/source/browse/unix/sockcmsg_linux.go?repo=sys
 
 package dbus


### PR DESCRIPTION
Ported godbus/dbus to DragonFly BSD.
