### PR TITLE
worker: don't drop signals

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -317,11 +317,7 @@ func (conn *Conn) inWorker() {
 				}
 				conn.signalsLck.Lock()
 				for _, ch := range conn.signals {
-					// don't block trying to send a signal
-					select {
-					case ch <- signal:
-					default:
-					}
+					ch <- signal
 				}
 				conn.signalsLck.Unlock()
 			case TypeMethodCall:


### PR DESCRIPTION
It is unreasonable to drop signals if the downstream client isn't
actively receiving. Force the client to receive a signal before
moving on so they aren't silently ignored.
