### PR TITLE
unlock mutex when releasing object

### DIFF
--- a/export.go
+++ b/export.go
@@ -225,6 +225,7 @@ func (conn *Conn) Export(v interface{}, path ObjectPath, iface string) error {
 				delete(conn.handlers, path)
 			}
 		}
+		conn.handlersLck.Unlock()
 		return nil
 	}
 	if _, ok := conn.handlers[path]; !ok {

--- a/export.go
+++ b/export.go
@@ -218,6 +218,7 @@ func (conn *Conn) Export(v interface{}, path ObjectPath, iface string) error {
 		return errors.New("dbus: invalid path name")
 	}
 	conn.handlersLck.Lock()
+	defer conn.handlersLck.Unlock()
 	if v == nil {
 		if _, ok := conn.handlers[path]; ok {
 			delete(conn.handlers[path], iface)
@@ -225,14 +226,12 @@ func (conn *Conn) Export(v interface{}, path ObjectPath, iface string) error {
 				delete(conn.handlers, path)
 			}
 		}
-		conn.handlersLck.Unlock()
 		return nil
 	}
 	if _, ok := conn.handlers[path]; !ok {
 		conn.handlers[path] = make(map[string]interface{})
 	}
 	conn.handlers[path][iface] = v
-	conn.handlersLck.Unlock()
 	return nil
 }
 


### PR DESCRIPTION
Its locking the mutex at the start of func call, but when releasing a object by passing `nil`, there is no `Unlock()` before return. So whole program freeze after one `Export(nil,.........)` call.