### PR TITLE
Support JSON marshalling of Variants to their associated values

### DIFF
--- a/_examples/signals-to-json.go
+++ b/_examples/signals-to-json.go
@@ -1,0 +1,61 @@
+package main
+
+/* Example usage, showing systemd unit property changes:
+ *
+ *   signals-to-json -systemBus=true -filter="type='signal',interface='org.freedesktop.DBus.Properties',member='PropertiesChanged',arg0='org.freedesktop.systemd1.Unit',path_namespace='/org/freedesktop/systemd1/unit'"
+ *
+ */
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"github.com/charles-dyfis-net/go-dbus"
+	"os"
+)
+
+var cfg struct {
+	Filter string
+	SystemBus bool
+}
+
+func main() {
+	var conn *dbus.Conn
+	var err error
+
+	flag.BoolVar(&cfg.SystemBus, "systemBus", false, "Use system rather than session bus")
+	flag.StringVar(&cfg.Filter, "filter", "", "Filter to apply to select signals (default looks for systemd service property changes)")
+	flag.Parse()
+
+	if(flag.NArg() != 0) {
+		fmt.Fprintf(os.Stderr, "Unrecognized argument seen\n")
+		flag.Usage()
+		os.Exit(1)
+	}
+
+	if(cfg.SystemBus) {
+		conn, err = dbus.SystemBus()
+	} else {
+		conn, err = dbus.SessionBus()
+	}
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "Failed to connect to system bus:", err)
+		os.Exit(1)
+	}
+
+	call := conn.BusObject().Call("org.freedesktop.DBus.AddMatch", 0, cfg.Filter)
+	if(call.Err != nil) {
+		panic(call.Err)
+	}
+
+	c := make(chan *dbus.Signal, 10)
+	conn.Signal(c)
+	for v := range c {
+		data, err := json.Marshal(v)
+		if(err != nil) {
+			fmt.Fprintf(os.Stderr, "Unable to marshal message %v: %s\n", err)
+		} else {
+			fmt.Println(string(data))
+		}
+	}
+}

--- a/dbus.go
+++ b/dbus.go
@@ -1,6 +1,7 @@
 package dbus
 
 import (
+	"encoding/json"
 	"errors"
 	"reflect"
 	"strings"
@@ -130,6 +131,10 @@ func hasStruct(v interface{}) bool {
 
 // An ObjectPath is an object path as defined by the D-Bus spec.
 type ObjectPath string
+
+func (op ObjectPath) MarshalJSON() ([]byte, error) {
+	return json.Marshal(string(op))
+}
 
 // IsValid returns whether the object path is valid.
 func (o ObjectPath) IsValid() bool {

--- a/variant.go
+++ b/variant.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"reflect"
+	"encoding/json"
 	"sort"
 	"strconv"
 )
@@ -12,6 +13,10 @@ import (
 type Variant struct {
 	sig   Signature
 	value interface{}
+}
+
+func (v Variant) MarshalJSON() ([]byte, error) {
+	return json.Marshal(v.Value())
 }
 
 // MakeVariant converts the given value to a Variant. It panics if v cannot be

--- a/variant_test.go
+++ b/variant_test.go
@@ -2,6 +2,7 @@ package dbus
 
 import "reflect"
 import "testing"
+import "encoding/json"
 
 var variantFormatTests = []struct {
 	v interface{}
@@ -73,6 +74,35 @@ func TestParseVariant(t *testing.T) {
 		}
 		if !reflect.DeepEqual(nv.value, v.v) {
 			t.Errorf("test %d: got %q, wanted %q", i+1, nv, v.v)
+		}
+	}
+}
+
+var variantJsonTests = []struct {
+	v interface{}
+	s string
+}{
+	{int32(1), `1`},
+	{"foo", `"foo"`},
+	{ObjectPath("/org/foo"), `"/org/foo"`},
+	{[]byte{}, `""`},
+	{[]int32{1, 2}, `[1,2]`},
+	{[]int64{1, 2}, `[1,2]`},
+	{[][]int32{{3, 4}, {5, 6}}, `[[3,4],[5,6]]`},
+	{[]Variant{MakeVariant(int32(1)), MakeVariant(1.0)}, `[1,1]`},
+	{map[string]int32{"one": 1, "two": 2}, `{"one":1,"two":2}`},
+	{map[string]Variant{}, `{}`},
+}
+
+func TestVariantJson(t *testing.T) {
+	for i, v := range variantJsonTests {
+		mv, err := json.Marshal(MakeVariant(v.v))
+		if(err != nil) {
+			t.Errorf("test %d: marshalling failed: %s", i+1, err)
+			continue
+		} else if (string(mv) != v.s) {
+			t.Errorf("test %d: got: <%s>, wanted: <%s>", i+1, mv, v.s)
+			continue
 		}
 	}
 }


### PR DESCRIPTION
Presently, Variant objects -- when marshalled to JSON -- are serialized as `{}`.

Marshalling to their values is considerably more useful behavior.
