### PR TITLE
Rewrite sessionBusPlatform: start dbus-daemon directly

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -9,7 +9,10 @@ import (
 	"sync"
 )
 
-const defaultSystemBusAddress = "unix:path=/var/run/dbus/system_bus_socket"
+const (
+	defaultSystemBusAddress = "unix:path=/var/run/dbus/system_bus_socket"
+	sessionBusAddressEnv    = "DBUS_SESSION_BUS_ADDRESS"
+)
 
 var (
 	systemBus     *Conn
@@ -91,7 +94,7 @@ func SessionBus() (conn *Conn, err error) {
 
 // SessionBusPrivate returns a new private connection to the session bus.
 func SessionBusPrivate() (*Conn, error) {
-	address := os.Getenv("DBUS_SESSION_BUS_ADDRESS")
+	address := os.Getenv(sessionBusAddressEnv)
 	if address != "" && address != "autolaunch:" {
 		return Dial(address)
 	}

--- a/conn_other.go
+++ b/conn_other.go
@@ -3,25 +3,78 @@
 package dbus
 
 import (
-	"bytes"
+	"bufio"
 	"errors"
+	"os"
 	"os/exec"
+	"sync"
+	"syscall"
+	"time"
 )
 
-func sessionBusPlatform() (*Conn, error) {
-	cmd := exec.Command("dbus-launch")
-	b, err := cmd.CombinedOutput()
+var (
+	dbusLaunchLock sync.Mutex
+)
 
+// startDbusDaemon starts a new dbus-daemon and returns its address or an error.
+func startDbusDaemon() (string, error) {
+	cmd := exec.Command("dbus-daemon", "--session", "--print-address",
+		"--nofork", "--nopidfile")
+	outPipe, err := cmd.StdoutPipe()
+	if err != nil {
+		return "", err
+	}
+
+	// If possible kill the process when the parent exits. This
+	// only works on Linux. On other systems dbus-daemon will
+	// become orphan.
+	cmd.SysProcAttr = &syscall.SysProcAttr{}
+	cmd.SysProcAttr.Pdeathsig = syscall.SIGTERM
+
+	err = cmd.Start()
+	if err != nil {
+		return "", err
+	}
+
+	type Output struct {
+		address string
+		err     error
+	}
+
+	ch := make(chan Output)
+	go func() {
+		reader := bufio.NewReader(outPipe)
+		line, err := reader.ReadString('\n')
+		ch <- Output{line, err}
+		close(ch)
+	}()
+
+	select {
+	case out := <-ch:
+		if out.err != nil {
+			return "", out.err
+		}
+		return out.address, nil
+	case <-time.After(time.Second):
+		cmd.Process.Kill()
+		return "", errors.New("cannot start dbus-daemon: timeout")
+	}
+}
+
+func sessionBusPlatform() (*Conn, error) {
+	dbusLaunchLock.Lock()
+	defer dbusLaunchLock.Unlock()
+
+	address := os.Getenv(sessionBusAddressEnv)
+	if address != "" && address != "autolaunch:" {
+		return Dial(address)
+	}
+
+	address, err := startDbusDaemon()
 	if err != nil {
 		return nil, err
 	}
+	os.Setenv(sessionBusAddressEnv, address)
 
-	i := bytes.IndexByte(b, '=')
-	j := bytes.IndexByte(b, '\n')
-
-	if i == -1 || j == -1 {
-		return nil, errors.New("dbus: couldn't determine address of session bus")
-	}
-
-	return Dial(string(b[i+1 : j]))
+	return Dial(address)
 }


### PR DESCRIPTION
Old implementation was starting dbus-daemon via dbus-launch. It had
several problems:
- dbus-launch detaches from parent. It never gets killed after the
  parent exits.
- old implementation would run a separate daemon each time you
  call SessionBusPrivate().
- DBUS_SESSION_BUS_ADDRESS env would never be set, so the session
  is not shared with child precesses.

New implementation launches dbus-daemon directly.
Also DBUS_SESSION_BUS_ADDRESS gets set, so that we only start the
daemon once and share the session with child processes.

Killing the process is achived by using PDEATHSIG - a feature only
available on Linux. On other systems we may still leave an orphan
process.
