### PR TITLE
Fix Introspect call to accept dbus.BusObject

### DIFF
--- a/introspect/call.go
+++ b/introspect/call.go
@@ -8,7 +8,7 @@ import (
 
 // Call calls org.freedesktop.Introspectable.Introspect on a remote object
 // and returns the introspection data.
-func Call(o *dbus.Object) (*Node, error) {
+func Call(o dbus.BusObject) (*Node, error) {
 	var xmldata string
 	var node Node
 


### PR DESCRIPTION
Introspect example code failed due to invalid argument type of dbus.BusObject (*dbus.Object expected). The call.go file in introspect has now been updated to fix this error by changing the argument type to dbus.BusObject.

Introspect example code now runs as expected.