### PR TITLE
Fix nil dereference

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -569,7 +569,7 @@ type transport interface {
 }
 
 var (
-	transports map[string]func(string) (transport, error) = make(map[string]func(string) (transport, error))
+	transports = make(map[string]func(string) (transport, error))
 )
 
 func getTransport(address string) (transport, error) {
@@ -586,6 +586,7 @@ func getTransport(address string) (transport, error) {
 		f := transports[v[:i]]
 		if f == nil {
 			err = errors.New("dbus: invalid bus address (invalid or unsupported transport)")
+			continue
 		}
 		t, err = f(v[i+1:])
 		if err == nil {


### PR DESCRIPTION
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal 0xb code=0x1 addr=0x0 pc=0x6a2aa]

goroutine 1 [running]:
github.com/godbus/dbus.getTransport(0x2221f0, 0x15, 0x0, 0x0, 0x0, 0x0)
	/Users/quentinperez/go/src/github.com/godbus/dbus/conn.go:592 +0x63a
github.com/godbus/dbus.Dial(0x2221f0, 0x15, 0x4c47, 0x0, 0x0)
	/Users/quentinperez/go/src/github.com/godbus/dbus/conn.go:143 +0x4f
```