### PR TITLE
conn: add RemoveSignal method to *Conn

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -499,9 +499,7 @@ func (conn *Conn) sendReply(dest string, serial uint32, values ...interface{}) {
 // The caller has to make sure that ch is sufficiently buffered; if a message
 // arrives when a write to c is not possible, it is discarded.
 //
-// Multiple of these channels can be registered at the same time. Passing a
-// channel that already is registered will remove it from the list of the
-// registered channels.
+// Multiple of these channels can be registered at the same time.
 //
 // These channels are "overwritten" by Eavesdrop; i.e., if there currently is a
 // channel for eavesdropped messages, this channel receives all signals, and
@@ -509,6 +507,17 @@ func (conn *Conn) sendReply(dest string, serial uint32, values ...interface{}) {
 func (conn *Conn) Signal(ch chan<- *Signal) {
 	conn.signalsLck.Lock()
 	conn.signals = append(conn.signals, ch)
+	conn.signalsLck.Unlock()
+}
+
+// RemoveSignal removes the given channel from the list of the registered channels.
+func (conn *Conn) RemoveSignal(ch chan<- *Signal) {
+	conn.signalsLck.Lock()
+	for i, c := range conn.signals {
+		if c == ch {
+			conn.signals = append(conn.signals[:i], conn.signals[i+1:]...)
+		}
+	}
 	conn.signalsLck.Unlock()
 }
 

--- a/conn.go
+++ b/conn.go
@@ -515,7 +515,9 @@ func (conn *Conn) RemoveSignal(ch chan<- *Signal) {
 	conn.signalsLck.Lock()
 	for i := len(conn.signals) - 1; i >= 0; i-- {
 		if ch == conn.signals[i] {
-			conn.signals = append(conn.signals[:i], conn.signals[i+1:]...)
+			copy(conn.signals[i:], conn.signals[i+1:])
+			conn.signals[len(conn.signals)-1] = nil
+			conn.signals = conn.signals[:len(conn.signals)-1]
 		}
 	}
 	conn.signalsLck.Unlock()

--- a/conn.go
+++ b/conn.go
@@ -513,8 +513,8 @@ func (conn *Conn) Signal(ch chan<- *Signal) {
 // RemoveSignal removes the given channel from the list of the registered channels.
 func (conn *Conn) RemoveSignal(ch chan<- *Signal) {
 	conn.signalsLck.Lock()
-	for i, c := range conn.signals {
-		if c == ch {
+	for i := len(conn.signals) - 1; i >= 0; i-- {
+		if ch == conn.signals[i] {
 			conn.signals = append(conn.signals[:i], conn.signals[i+1:]...)
 		}
 	}

--- a/conn_test.go
+++ b/conn_test.go
@@ -39,6 +39,30 @@ func TestSend(t *testing.T) {
 	}
 }
 
+func TestRemoveSignal(t *testing.T) {
+	bus, err := NewConn(nil)
+	if err != nil {
+		t.Error(err)
+	}
+	ch := make(chan *Signal)
+	ch2 := make(chan *Signal)
+	for _, ch := range []chan *Signal{ch, ch2, ch, ch2, ch2, ch} {
+		bus.Signal(ch)
+	}
+	if len(bus.signals) != 6 {
+		t.Errorf("remove signal: signals length not equal: got '%d', want '6'", len(bus.signals))
+	}
+	bus.RemoveSignal(ch)
+	if len(bus.signals) != 3 {
+		t.Errorf("remove signal: signals length not equal: got '%d', want '3'", len(bus.signals))
+	}
+	for _, bch := range bus.signals {
+		if bch != ch2 {
+			t.Errorf("remove signal: removed signal present: got '%v', want '%v'", bch, ch2)
+		}
+	}
+}
+
 type server struct{}
 
 func (server) Double(i int64) (int64, *Error) {


### PR DESCRIPTION
Although `Signal` states "[p]assing a channel that already is registered will remove it from the [...] registered channels." this is not actually done. As a result there is no way to remove a signal once it has been registered.

This PR adds a `RemoveSignal` method that finds and removes all instances of `ch chan<- *Signal` from `conn.signals`.