### PR TITLE
Add support for Dial("tcp:host=..,port=..")

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -610,16 +610,11 @@ func dereferenceAll(vs []interface{}) []interface{} {
 
 // getKey gets a key from a the list of keys. Returns "" on error / not found...
 func getKey(s, key string) string {
-	i := strings.Index(s, key)
-	if i == -1 {
-		return ""
+	for _, keyEqualsValue := range strings.Split(s, ",") {
+		keyValue := strings.SplitN(keyEqualsValue, "=", 2)
+		if len(keyValue) == 2 && keyValue[0] == key {
+			return keyValue[1]
+		}
 	}
-	if i+len(key)+1 >= len(s) || s[i+len(key)] != '=' {
-		return ""
-	}
-	j := strings.Index(s, ",")
-	if j == -1 {
-		j = len(s)
-	}
-	return s[i+len(key)+1 : j]
+	return ""
 }

--- a/conn_test.go
+++ b/conn_test.go
@@ -197,3 +197,16 @@ func benchmarkServeAsync(b *testing.B, srv, cli *Conn) {
 	}
 	<-done
 }
+
+func TestGetKey(t *testing.T) {
+	keys := "host=1.2.3.4,port=5678,family=ipv4"
+	if host := getKey(keys, "host"); host != "1.2.3.4" {
+		t.Error(`Expected "1.2.3.4", got`, host)
+	}
+	if port := getKey(keys, "port"); port != "5678" {
+		t.Error(`Expected "5678", got`, port)
+	}
+	if family := getKey(keys, "family"); family != "ipv4" {
+		t.Error(`Expected "ipv4", got`, family)
+	}
+}

--- a/transport_tcp.go
+++ b/transport_tcp.go
@@ -1,0 +1,43 @@
+//+build !windows
+
+package dbus
+
+import (
+	"errors"
+	"net"
+)
+
+func init() {
+	transports["tcp"] = newTcpTransport
+}
+
+func tcpFamily(keys string) (string, error) {
+	switch getKey(keys, "family") {
+	case "":
+		return "tcp", nil
+	case "ipv4":
+		return "tcp4", nil
+	case "ipv6":
+		return "tcp6", nil
+	default:
+		return "", errors.New("dbus: invalid tcp family (must be ipv4 or ipv6)")
+	}
+}
+
+func newTcpTransport(keys string) (transport, error) {
+	host := getKey(keys, "host")
+	port := getKey(keys, "port")
+	if host == "" || port == "" {
+		return nil, errors.New("dbus: unsupported address (must set host and port)")
+	}
+
+	protocol, err := tcpFamily(keys)
+	if err != nil {
+		return nil, err
+	}
+	socket, err := net.Dial(protocol, net.JoinHostPort(host, port))
+	if err != nil {
+		return nil, err
+	}
+	return NewConn(socket)
+}

--- a/transport_tcp_test.go
+++ b/transport_tcp_test.go
@@ -1,0 +1,26 @@
+package dbus
+
+import (
+	"fmt"
+	"net"
+	"testing"
+)
+
+func TestTcpConnection(t *testing.T) {
+	listener, err := net.Listen("tcp", ":0")
+	if err != nil {
+		t.Fatal("Failed to create listener")
+	}
+	host, port, err := net.SplitHostPort(listener.Addr().String())
+	if err != nil {
+		t.Fatal("Failed to parse host/port")
+	}
+
+	conn, err := Dial(fmt.Sprintf("tcp:host=%s,port=%s", host, port))
+	if err != nil {
+		t.Error("Expected no error, got", err)
+	}
+	if conn == nil {
+		t.Error("Expected connection, got nil")
+	}
+}


### PR DESCRIPTION
Hello

I added support for TCP connections based on NewConn() to the map of supported "transports".

I also changed getKey() to reuse it for TCP keys.
The original version set "j" to the first occurrence of ",", even when "i" found to a later key.