### PR TITLE
Fix nil dereference

### DIFF
--- a/conn_test.go
+++ b/conn_test.go
@@ -19,7 +19,7 @@ func TestSystemBus(t *testing.T) {
 func TestSend(t *testing.T) {
 	bus, err := SessionBus()
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 	ch := make(chan *Call, 1)
 	msg := &Message{


### PR DESCRIPTION
```console
$> go test -v
...
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
	panic: runtime error: invalid memory address or nil pointer dereference
[signal 0xb code=0x1 addr=0x0 pc=0x893fa]

goroutine 23 [running]:
testing.tRunner.func1(0xc8200a0630)
	/usr/local/Cellar/go/1.5.1/libexec/src/testing/testing.go:450 +0x171
github.com/godbus/dbus.(*Conn).Names(0x0, 0x0, 0x0, 0x0)
	/Users/quentinperez/go/src/github.com/godbus/dbus/conn.go:369 +0x11a
github.com/godbus/dbus.TestSend(0xc8200a0630)
	/Users/quentinperez/go/src/github.com/godbus/dbus/conn_test.go:29 +0x15c
testing.tRunner(0xc8200a0630, 0x3be590)
	/usr/local/Cellar/go/1.5.1/libexec/src/testing/testing.go:456 +0x98
created by testing.RunTests
	/usr/local/Cellar/go/1.5.1/libexec/src/testing/testing.go:561 +0x86d

goroutine 1 [chan receive]:
testing.RunTests(0x2f1548, 0x3be560, 0x1c, 0x1c, 0x0)
	/usr/local/Cellar/go/1.5.1/libexec/src/testing/testing.go:562 +0x8ad
testing.(*M).Run(0xc82004def8, 0x2875b8)
	/usr/local/Cellar/go/1.5.1/libexec/src/testing/testing.go:494 +0x70
main.main()
	github.com/godbus/dbus/_test/_testmain.go:132 +0x116
...
```
