### PR TITLE
honor introspection calls on sub path of every exported object

### DIFF
--- a/export.go
+++ b/export.go
@@ -133,6 +133,23 @@ func (conn *Conn) handleCall(msg *Message) {
 			conn.sendError(errmsgUnknownMethod, sender, serial)
 		}
 		return
+	} else if ifaceName == "org.freedesktop.DBus.Introspectable" && name == "Introspect" {
+		if _, ok := conn.handlers[path]; !ok {
+			xml := "<node>"
+			for h, _ := range conn.handlers {
+				p := string(path)
+				if p != "/" {
+					p += "/"
+				}
+				if strings.HasPrefix(string(h), p) {
+					node_name := strings.Split(string(h[len(p):]), "/")[0]
+					xml = xml + "\n    <node name=\"" + node_name + "\"/>"
+				}
+			}
+			xml += "\n</node>"
+			conn.sendReply(sender, serial, xml)
+			return
+		}
 	}
 	if len(name) == 0 {
 		conn.sendError(errmsgUnknownMethod, sender, serial)


### PR DESCRIPTION
This is the same pull request @rrerolle has submitted for [go.dbus](https://github.com/guelfey/go.dbus/pull/53). 

As you said you'd like to have the PR in this repo. So here it is :) It fixes the error in `d-feet` and `qdbusviewer` which improves debugging with these tools.

```
com.github.guelfey.Demo :
GDBus.Error:org.freedesktop.DBus.Error.NoSuchObject: No such object
```