### PR TITLE
get godbus/dbus to compile on Solaris

### DIFF
--- a/transport_unix.go
+++ b/transport_unix.go
@@ -1,4 +1,4 @@
-//+build !windows
+//+build !windows,!solaris
 
 package dbus
 


### PR DESCRIPTION
godbus/dbus currently does not build on Solaris. This PR fixes it by building the trasnsport_generic.go on Solaris.
This is a temporary fix. As godbus/dbus is a dependency for Docker, we are doing this to enable Docker to build clean on Solaris.
We will follow up with another PR that provides a feature implementation i.e. transport_unix.go with a transport_unixcred_solaris.go . This is pending a minor enhancement for golang on Solaris.

Signed-off-by: Amit Krishnan <krish.amit@gmail.com>