### PR TITLE
Refactor connection implementation details

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -47,16 +47,13 @@ type Conn struct {
 	calls    map[uint32]*Call
 	callsLck sync.RWMutex
 
-	handlers    map[ObjectPath]map[string]exportedObj
-	handlersLck sync.RWMutex
+	handler Handler
 
 	out    chan *Message
 	closed bool
 	outLck sync.RWMutex
 
-	signals       []chan<- *Signal
-	signalsClosed bool
-	signalsLck    sync.Mutex
+	signalHandler SignalHandler
 
 	eavesdropped    chan<- *Message
 	eavesdroppedLck sync.Mutex
@@ -91,16 +88,33 @@ func SessionBus() (conn *Conn, err error) {
 	return
 }
 
-// SessionBusPrivate returns a new private connection to the session bus.
-func SessionBusPrivate() (*Conn, error) {
+func getSessionBusAddress() (string, error) {
 	sessionEnvLck.Lock()
 	defer sessionEnvLck.Unlock()
 	address := os.Getenv("DBUS_SESSION_BUS_ADDRESS")
 	if address != "" && address != "autolaunch:" {
-		return Dial(address)
+		return address, nil
+	}
+	return getSessionBusPlatformAddress()
+}
+
+// SessionBusPrivate returns a new private connection to the session bus.
+func SessionBusPrivate() (*Conn, error) {
+	address, err := getSessionBusAddress()
+	if err != nil {
+		return nil, err
 	}
 
-	return sessionBusPlatform()
+	return Dial(address)
+}
+
+// SessionBusPrivate returns a new private connection to the session bus.
+func SessionBusPrivateHandler(handler Handler, signalHandler SignalHandler) (*Conn, error) {
+	address, err := getSessionBusAddress()
+	if err != nil {
+		return nil, err
+	}
+	return DialHandler(address, handler, signalHandler)
 }
 
 // SystemBus returns a shared connection to the system bus, connecting to it if
@@ -132,13 +146,22 @@ func SystemBus() (conn *Conn, err error) {
 	return
 }
 
-// SystemBusPrivate returns a new private connection to the system bus.
-func SystemBusPrivate() (*Conn, error) {
+func getSystemBusAddress() string {
 	address := os.Getenv("DBUS_SYSTEM_BUS_ADDRESS")
 	if address != "" {
-		return Dial(address)
+		return address
 	}
-	return Dial(defaultSystemBusAddress)
+	return defaultSystemBusAddress
+}
+
+// SystemBusPrivate returns a new private connection to the system bus.
+func SystemBusPrivate() (*Conn, error) {
+	return Dial(getSystemBusAddress())
+}
+
+// SystemBusPrivateHandler returns a new private connection to the system bus, using the provided handlers.
+func SystemBusPrivateHandler(handler Handler, signalHandler SignalHandler) (*Conn, error) {
+	return DialHandler(getSystemBusAddress(), handler, signalHandler)
 }
 
 // Dial establishes a new private connection to the message bus specified by address.
@@ -147,21 +170,36 @@ func Dial(address string) (*Conn, error) {
 	if err != nil {
 		return nil, err
 	}
-	return newConn(tr)
+	return newConn(tr, newDefaultHandler(), newDefaultSignalHandler())
+}
+
+// DialHandler establishes a new private connection to the message bus specified by address, using the supplied handlers.
+func DialHandler(address string, handler Handler, signalHandler SignalHandler) (*Conn, error) {
+	tr, err := getTransport(address)
+	if err != nil {
+		return nil, err
+	}
+	return newConn(tr, handler, signalHandler)
 }
 
 // NewConn creates a new private *Conn from an already established connection.
 func NewConn(conn io.ReadWriteCloser) (*Conn, error) {
-	return newConn(genericTransport{conn})
+	return NewConnHandler(conn, newDefaultHandler(), newDefaultSignalHandler())
+}
+
+// NewConnHandler creates a new private *Conn from an already established connection, using the supplied handlers.
+func NewConnHandler(conn io.ReadWriteCloser, handler Handler, signalHandler SignalHandler) (*Conn, error) {
+	return newConn(genericTransport{conn}, handler, signalHandler)
 }
 
 // newConn creates a new *Conn from a transport.
-func newConn(tr transport) (*Conn, error) {
+func newConn(tr transport, handler Handler, signalHandler SignalHandler) (*Conn, error) {
 	conn := new(Conn)
 	conn.transport = tr
 	conn.calls = make(map[uint32]*Call)
 	conn.out = make(chan *Message, 10)
-	conn.handlers = make(map[ObjectPath]map[string]exportedObj)
+	conn.handler = handler
+	conn.signalHandler = signalHandler
 	conn.nextSerial = 1
 	conn.serialUsed = map[uint32]bool{0: true}
 	conn.busObj = conn.Object("org.freedesktop.DBus", "/org/freedesktop/DBus")
@@ -189,17 +227,21 @@ func (conn *Conn) Close() error {
 	close(conn.out)
 	conn.closed = true
 	conn.outLck.Unlock()
-	conn.signalsLck.Lock()
-	conn.signalsClosed = true
-	for _, ch := range conn.signals {
-		close(ch)
+
+	if term, ok := conn.signalHandler.(Terminator); ok {
+		term.Terminate()
 	}
-	conn.signalsLck.Unlock()
+
+	if term, ok := conn.handler.(Terminator); ok {
+		term.Terminate()
+	}
+
 	conn.eavesdroppedLck.Lock()
 	if conn.eavesdropped != nil {
 		close(conn.eavesdropped)
 	}
 	conn.eavesdroppedLck.Unlock()
+
 	return conn.transport.Close()
 }
 
@@ -336,21 +378,7 @@ func (conn *Conn) inWorker() {
 						conn.namesLck.Unlock()
 					}
 				}
-				signal := &Signal{
-					Sender: sender,
-					Path:   msg.Headers[FieldPath].value.(ObjectPath),
-					Name:   iface + "." + member,
-					Body:   msg.Body,
-				}
-				conn.signalsLck.Lock()
-				if conn.signalsClosed {
-					conn.signalsLck.Unlock()
-					return
-				}
-				for _, ch := range conn.signals {
-					ch <- signal
-				}
-				conn.signalsLck.Unlock()
+				go conn.handleSignal(msg)
 			case TypeMethodCall:
 				go conn.handleCall(msg)
 			}
@@ -369,6 +397,21 @@ func (conn *Conn) inWorker() {
 		}
 		// invalid messages are ignored
 	}
+}
+
+func (conn *Conn) handleSignal(msg *Message) {
+	iface := msg.Headers[FieldInterface].value.(string)
+	member := msg.Headers[FieldMember].value.(string)
+	// as per http://dbus.freedesktop.org/doc/dbus-specification.html ,
+	// sender is optional for signals.
+	sender, _ := msg.Headers[FieldSender].value.(string)
+	signal := &Signal{
+		Sender: sender,
+		Path:   msg.Headers[FieldPath].value.(ObjectPath),
+		Name:   iface + "." + member,
+		Body:   msg.Body,
+	}
+	conn.signalHandler.DeliverSignal(iface, member, signal)
 }
 
 // Names returns the list of all names that are currently owned by this
@@ -461,7 +504,18 @@ func (conn *Conn) Send(msg *Message, ch chan *Call) *Call {
 
 // sendError creates an error message corresponding to the parameters and sends
 // it to conn.out.
-func (conn *Conn) sendError(e Error, dest string, serial uint32) {
+func (conn *Conn) sendError(err error, dest string, serial uint32) {
+	var e *Error
+	switch em := err.(type) {
+	case Error:
+		e = &em
+	case *Error:
+		e = em
+	case DBusError:
+		e = em.DBusError()
+	default:
+		e = MakeFailedError(err)
+	}
 	msg := new(Message)
 	msg.Type = TypeError
 	msg.serial = conn.getSerial()
@@ -504,6 +558,14 @@ func (conn *Conn) sendReply(dest string, serial uint32, values ...interface{}) {
 	conn.outLck.RUnlock()
 }
 
+func (conn *Conn) defaultSignalAction(fn func(h *defaultSignalHandler, ch chan<- *Signal), ch chan<- *Signal) {
+	if !isDefaultSignalHandler(conn.signalHandler) {
+		return
+	}
+	handler := conn.signalHandler.(*defaultSignalHandler)
+	fn(handler, ch)
+}
+
 // Signal registers the given channel to be passed all received signal messages.
 // The caller has to make sure that ch is sufficiently buffered; if a message
 // arrives when a write to c is not possible, it is discarded.
@@ -514,22 +576,12 @@ func (conn *Conn) sendReply(dest string, serial uint32, values ...interface{}) {
 // channel for eavesdropped messages, this channel receives all signals, and
 // none of the channels passed to Signal will receive any signals.
 func (conn *Conn) Signal(ch chan<- *Signal) {
-	conn.signalsLck.Lock()
-	conn.signals = append(conn.signals, ch)
-	conn.signalsLck.Unlock()
+	conn.defaultSignalAction((*defaultSignalHandler).addSignal, ch)
 }
 
 // RemoveSignal removes the given channel from the list of the registered channels.
 func (conn *Conn) RemoveSignal(ch chan<- *Signal) {
-	conn.signalsLck.Lock()
-	for i := len(conn.signals) - 1; i >= 0; i-- {
-		if ch == conn.signals[i] {
-			copy(conn.signals[i:], conn.signals[i+1:])
-			conn.signals[len(conn.signals)-1] = nil
-			conn.signals = conn.signals[:len(conn.signals)-1]
-		}
-	}
-	conn.signalsLck.Unlock()
+	conn.defaultSignalAction((*defaultSignalHandler).removeSignal, ch)
 }
 
 // SupportsUnixFDs returns whether the underlying transport supports passing of

--- a/conn_darwin.go
+++ b/conn_darwin.go
@@ -5,17 +5,17 @@ import (
 	"os/exec"
 )
 
-func sessionBusPlatform() (*Conn, error) {
+func getSessionBusPlatformAddress() (string, error) {
 	cmd := exec.Command("launchctl", "getenv", "DBUS_LAUNCHD_SESSION_BUS_SOCKET")
 	b, err := cmd.CombinedOutput()
 
 	if err != nil {
-		return nil, err
+		return "", err
 	}
 
 	if len(b) == 0 {
-		return nil, errors.New("dbus: couldn't determine address of session bus")
+		return "", errors.New("dbus: couldn't determine address of session bus")
 	}
 
-	return Dial("unix:path=" + string(b[:len(b)-1]))
+	return "unix:path=" + string(b[:len(b)-1]), nil
 }

--- a/conn_other.go
+++ b/conn_other.go
@@ -9,23 +9,23 @@ import (
 	"os/exec"
 )
 
-func sessionBusPlatform() (*Conn, error) {
+func getSessionBusPlatformAddress() (string, error) {
 	cmd := exec.Command("dbus-launch")
 	b, err := cmd.CombinedOutput()
 
 	if err != nil {
-		return nil, err
+		return "", err
 	}
 
 	i := bytes.IndexByte(b, '=')
 	j := bytes.IndexByte(b, '\n')
 
 	if i == -1 || j == -1 {
-		return nil, errors.New("dbus: couldn't determine address of session bus")
+		return "", errors.New("dbus: couldn't determine address of session bus")
 	}
 
 	env, addr := string(b[0:i]), string(b[i+1:j])
 	os.Setenv(env, addr)
 
-	return Dial(addr)
+	return addr, nil
 }

--- a/conn_test.go
+++ b/conn_test.go
@@ -49,19 +49,23 @@ func TestRemoveSignal(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
+	signals := bus.signalHandler.(*defaultSignalHandler).signals
 	ch := make(chan *Signal)
 	ch2 := make(chan *Signal)
 	for _, ch := range []chan *Signal{ch, ch2, ch, ch2, ch2, ch} {
 		bus.Signal(ch)
 	}
-	if len(bus.signals) != 6 {
-		t.Errorf("remove signal: signals length not equal: got '%d', want '6'", len(bus.signals))
+	signals = bus.signalHandler.(*defaultSignalHandler).signals
+	if len(signals) != 6 {
+		t.Errorf("remove signal: signals length not equal: got '%d', want '6'", len(signals))
 	}
 	bus.RemoveSignal(ch)
-	if len(bus.signals) != 3 {
-		t.Errorf("remove signal: signals length not equal: got '%d', want '3'", len(bus.signals))
+	signals = bus.signalHandler.(*defaultSignalHandler).signals
+	if len(signals) != 3 {
+		t.Errorf("remove signal: signals length not equal: got '%d', want '3'", len(signals))
 	}
-	for _, bch := range bus.signals {
+	signals = bus.signalHandler.(*defaultSignalHandler).signals
+	for _, bch := range signals {
 		if bch != ch2 {
 			t.Errorf("remove signal: removed signal present: got '%v', want '%v'", bch, ch2)
 		}

--- a/default_handler.go
+++ b/default_handler.go
@@ -1,0 +1,283 @@
+package dbus
+
+import (
+	"bytes"
+	"reflect"
+	"strings"
+	"sync"
+)
+
+func newIntrospectIntf(h *defaultHandler) *exportedIntf {
+	methods := make(map[string]Method)
+	methods["Introspect"] = exportedMethod{
+		reflect.ValueOf(func(msg Message) (string, *Error) {
+			path := msg.Headers[FieldPath].value.(ObjectPath)
+			return h.introspectPath(path), nil
+		}),
+	}
+	return newExportedIntf(methods, true)
+}
+
+func newDefaultHandler() *defaultHandler {
+	h := &defaultHandler{
+		objects:     make(map[ObjectPath]*exportedObj),
+		defaultIntf: make(map[string]*exportedIntf),
+	}
+	h.defaultIntf["org.freedesktop.DBus.Introspectable"] = newIntrospectIntf(h)
+	return h
+}
+
+type defaultHandler struct {
+	sync.RWMutex
+	objects     map[ObjectPath]*exportedObj
+	defaultIntf map[string]*exportedIntf
+}
+
+func (h *defaultHandler) PathExists(path ObjectPath) bool {
+	_, ok := h.objects[path]
+	return ok
+}
+
+func (h *defaultHandler) introspectPath(path ObjectPath) string {
+	subpath := make(map[string]struct{})
+	var xml bytes.Buffer
+	xml.WriteString("<node>")
+	for obj, _ := range h.objects {
+		p := string(path)
+		if p != "/" {
+			p += "/"
+		}
+		if strings.HasPrefix(string(obj), p) {
+			node_name := strings.Split(string(obj[len(p):]), "/")[0]
+			subpath[node_name] = struct{}{}
+		}
+	}
+	for s, _ := range subpath {
+		xml.WriteString("\n\t<node name=\"" + s + "\"/>")
+	}
+	xml.WriteString("\n</node>")
+	return xml.String()
+}
+
+func (h *defaultHandler) LookupObject(path ObjectPath) (ServerObject, bool) {
+	h.RLock()
+	defer h.RUnlock()
+	object, ok := h.objects[path]
+	if ok {
+		return object, ok
+	}
+
+	// If an object wasn't found for this exact path,
+	// look for a matching subtree registration
+	subtreeObject := newExportedObject()
+	path = path[:strings.LastIndex(string(path), "/")]
+	for len(path) > 0 {
+		object, ok = h.objects[path]
+		if ok {
+			for name, iface := range object.interfaces {
+				// Only include this handler if it registered for the subtree
+				if iface.isFallbackInterface() {
+					subtreeObject.interfaces[name] = iface
+				}
+			}
+			break
+		}
+
+		path = path[:strings.LastIndex(string(path), "/")]
+	}
+
+	for name, intf := range h.defaultIntf {
+		if _, exists := subtreeObject.interfaces[name]; exists {
+			continue
+		}
+		subtreeObject.interfaces[name] = intf
+	}
+
+	return subtreeObject, true
+}
+
+func (h *defaultHandler) AddObject(path ObjectPath, object *exportedObj) {
+	h.Lock()
+	h.objects[path] = object
+	h.Unlock()
+}
+
+func (h *defaultHandler) DeleteObject(path ObjectPath) {
+	h.Lock()
+	delete(h.objects, path)
+	h.Unlock()
+}
+
+type exportedMethod struct {
+	reflect.Value
+}
+
+func (m exportedMethod) Call(args ...interface{}) ([]interface{}, error) {
+	t := m.Type()
+
+	params := make([]reflect.Value, len(args))
+	for i := 0; i < len(args); i++ {
+		params[i] = reflect.ValueOf(args[i]).Elem()
+	}
+
+	ret := m.Value.Call(params)
+
+	err := ret[t.NumOut()-1].Interface().(*Error)
+	ret = ret[:t.NumOut()-1]
+	out := make([]interface{}, len(ret))
+	for i, val := range ret {
+		out[i] = val.Interface()
+	}
+	if err == nil {
+		//concrete type to interface nil is a special case
+		return out, nil
+	}
+	return out, err
+}
+
+func (m exportedMethod) NumArguments() int {
+	return m.Value.Type().NumIn()
+}
+
+func (m exportedMethod) ArgumentValue(i int) interface{} {
+	return reflect.Zero(m.Type().In(i)).Interface()
+}
+
+func (m exportedMethod) NumReturns() int {
+	return m.Value.Type().NumOut()
+}
+
+func (m exportedMethod) ReturnValue(i int) interface{} {
+	return reflect.Zero(m.Type().Out(i)).Interface()
+}
+
+func newExportedObject() *exportedObj {
+	return &exportedObj{
+		interfaces: make(map[string]*exportedIntf),
+	}
+}
+
+type exportedObj struct {
+	interfaces map[string]*exportedIntf
+}
+
+func (obj *exportedObj) LookupInterface(name string) (Interface, bool) {
+	if name == "" {
+		return obj, true
+	}
+	intf, exists := obj.interfaces[name]
+	return intf, exists
+}
+
+func (obj *exportedObj) AddInterface(name string, iface *exportedIntf) {
+	obj.interfaces[name] = iface
+}
+
+func (obj *exportedObj) DeleteInterface(name string) {
+	delete(obj.interfaces, name)
+}
+
+func (obj *exportedObj) LookupMethod(name string) (Method, bool) {
+	for _, intf := range obj.interfaces {
+		method, exists := intf.LookupMethod(name)
+		if exists {
+			return method, exists
+		}
+	}
+	return nil, false
+}
+
+func (obj *exportedObj) isFallbackInterface() bool {
+	return false
+}
+
+func newExportedIntf(methods map[string]Method, includeSubtree bool) *exportedIntf {
+	return &exportedIntf{
+		methods:        methods,
+		includeSubtree: includeSubtree,
+	}
+}
+
+type exportedIntf struct {
+	methods map[string]Method
+
+	// Whether or not this export is for the entire subtree
+	includeSubtree bool
+}
+
+func (obj *exportedIntf) LookupMethod(name string) (Method, bool) {
+	out, exists := obj.methods[name]
+	return out, exists
+}
+
+func (obj *exportedIntf) isFallbackInterface() bool {
+	return obj.includeSubtree
+}
+
+func newDefaultSignalHandler() *defaultSignalHandler {
+	return &defaultSignalHandler{}
+}
+
+func isDefaultSignalHandler(handler SignalHandler) bool {
+	_, ok := handler.(*defaultSignalHandler)
+	return ok
+}
+
+type defaultSignalHandler struct {
+	sync.RWMutex
+	closed  bool
+	signals []chan<- *Signal
+}
+
+func (sh *defaultSignalHandler) DeliverSignal(intf, name string, signal *Signal) {
+	sh.RLock()
+	defer sh.RUnlock()
+	if sh.closed {
+		return
+	}
+	for _, ch := range sh.signals {
+		ch <- signal
+	}
+}
+
+func (sh *defaultSignalHandler) Init() error {
+	sh.Lock()
+	sh.signals = make([]chan<- *Signal, 0)
+	sh.Unlock()
+	return nil
+}
+
+func (sh *defaultSignalHandler) Terminate() {
+	sh.Lock()
+	sh.closed = true
+	for _, ch := range sh.signals {
+		close(ch)
+	}
+	sh.signals = nil
+	sh.Unlock()
+}
+
+func (sh *defaultSignalHandler) addSignal(ch chan<- *Signal) {
+	sh.Lock()
+	defer sh.Unlock()
+	if sh.closed {
+		return
+	}
+	sh.signals = append(sh.signals, ch)
+
+}
+
+func (sh *defaultSignalHandler) removeSignal(ch chan<- *Signal) {
+	sh.Lock()
+	defer sh.Unlock()
+	if sh.closed {
+		return
+	}
+	for i := len(sh.signals) - 1; i >= 0; i-- {
+		if ch == sh.signals[i] {
+			copy(sh.signals[i:], sh.signals[i+1:])
+			sh.signals[len(sh.signals)-1] = nil
+			sh.signals = sh.signals[:len(sh.signals)-1]
+		}
+	}
+}

--- a/export.go
+++ b/export.go
@@ -1,7 +1,6 @@
 package dbus
 
 import (
-	"bytes"
 	"errors"
 	"fmt"
 	"reflect"
@@ -9,32 +8,29 @@ import (
 )
 
 var (
-	errmsgInvalidArg = Error{
+	ErrMsgInvalidArg = Error{
 		"org.freedesktop.DBus.Error.InvalidArgs",
 		[]interface{}{"Invalid type / number of args"},
 	}
-	errmsgNoObject = Error{
+	ErrMsgNoObject = Error{
 		"org.freedesktop.DBus.Error.NoSuchObject",
 		[]interface{}{"No such object"},
 	}
-	errmsgUnknownMethod = Error{
+	ErrMsgUnknownMethod = Error{
 		"org.freedesktop.DBus.Error.UnknownMethod",
 		[]interface{}{"Unknown / invalid method"},
 	}
+	ErrMsgUnknownInterface = Error{
+		"org.freedesktop.DBus.Error.UnknownInterface",
+		[]interface{}{"Object does not implement the interface"},
+	}
 )
 
-// exportedObj represents an exported object. It stores a precomputed
-// method table that represents the methods exported on the bus.
-type exportedObj struct {
-	methods map[string]reflect.Value
-
-	// Whether or not this export is for the entire subtree
-	includeSubtree bool
-}
-
-func (obj exportedObj) Method(name string) (reflect.Value, bool) {
-	out, exists := obj.methods[name]
-	return out, exists
+func MakeFailedError(err error) *Error {
+	return &Error{
+		"org.freedesktop.DBus.Error.Failed",
+		[]interface{}{err},
+	}
 }
 
 // Sender is a type which can be used in exported methods to receive the message
@@ -63,7 +59,7 @@ func getMethods(in interface{}, mapping map[string]string) map[string]reflect.Va
 		// only track valid methods must return *Error as last arg
 		// and must be exported
 		if t.NumOut() == 0 ||
-			t.Out(t.NumOut()-1) != reflect.TypeOf(&errmsgInvalidArg) ||
+			t.Out(t.NumOut()-1) != reflect.TypeOf(&ErrMsgInvalidArg) ||
 			methtype.PkgPath != "" {
 			continue
 		}
@@ -73,119 +69,12 @@ func getMethods(in interface{}, mapping map[string]string) map[string]reflect.Va
 	return methods
 }
 
-// searchHandlers will look through all registered handlers looking for one
-// to handle the given path. If a verbatim one isn't found, it will check for
-// a subtree registration for the path as well.
-func (conn *Conn) searchHandlers(path ObjectPath) (map[string]exportedObj, bool) {
-	conn.handlersLck.RLock()
-	defer conn.handlersLck.RUnlock()
+func standardMethodArgumentDecode(m Method, sender string, msg *Message, body []interface{}) ([]interface{}, error) {
+	pointers := make([]interface{}, m.NumArguments())
+	decode := make([]interface{}, 0, len(body))
 
-	handlers, ok := conn.handlers[path]
-	if ok {
-		return handlers, ok
-	}
-
-	// If handlers weren't found for this exact path, look for a matching subtree
-	// registration
-	handlers = make(map[string]exportedObj)
-	path = path[:strings.LastIndex(string(path), "/")]
-	for len(path) > 0 {
-		var subtreeHandlers map[string]exportedObj
-		subtreeHandlers, ok = conn.handlers[path]
-		if ok {
-			for iface, handler := range subtreeHandlers {
-				// Only include this handler if it registered for the subtree
-				if handler.includeSubtree {
-					handlers[iface] = handler
-				}
-			}
-
-			break
-		}
-
-		path = path[:strings.LastIndex(string(path), "/")]
-	}
-
-	return handlers, ok
-}
-
-// handleCall handles the given method call (i.e. looks if it's one of the
-// pre-implemented ones and searches for a corresponding handler if not).
-func (conn *Conn) handleCall(msg *Message) {
-	name := msg.Headers[FieldMember].value.(string)
-	path := msg.Headers[FieldPath].value.(ObjectPath)
-	ifaceName, hasIface := msg.Headers[FieldInterface].value.(string)
-	sender, hasSender := msg.Headers[FieldSender].value.(string)
-	serial := msg.serial
-	if ifaceName == "org.freedesktop.DBus.Peer" {
-		switch name {
-		case "Ping":
-			conn.sendReply(sender, serial)
-		case "GetMachineId":
-			conn.sendReply(sender, serial, conn.uuid)
-		default:
-			conn.sendError(errmsgUnknownMethod, sender, serial)
-		}
-		return
-	} else if ifaceName == "org.freedesktop.DBus.Introspectable" && name == "Introspect" {
-		if _, ok := conn.handlers[path]; !ok {
-			subpath := make(map[string]struct{})
-			var xml bytes.Buffer
-			xml.WriteString("<node>")
-			for h, _ := range conn.handlers {
-				p := string(path)
-				if p != "/" {
-					p += "/"
-				}
-				if strings.HasPrefix(string(h), p) {
-					node_name := strings.Split(string(h[len(p):]), "/")[0]
-					subpath[node_name] = struct{}{}
-				}
-			}
-			for s, _ := range subpath {
-				xml.WriteString("\n\t<node name=\"" + s + "\"/>")
-			}
-			xml.WriteString("\n</node>")
-			conn.sendReply(sender, serial, xml.String())
-			return
-		}
-	}
-	if len(name) == 0 {
-		conn.sendError(errmsgUnknownMethod, sender, serial)
-	}
-
-	// Find the exported handler (if any) for this path
-	handlers, ok := conn.searchHandlers(path)
-	if !ok {
-		conn.sendError(errmsgNoObject, sender, serial)
-		return
-	}
-
-	var m reflect.Value
-	var exists bool
-	if hasIface {
-		iface := handlers[ifaceName]
-		m, exists = iface.Method(name)
-	} else {
-		for _, v := range handlers {
-			m, exists = v.Method(name)
-			if exists {
-				break
-			}
-		}
-	}
-
-	if !exists {
-		conn.sendError(errmsgUnknownMethod, sender, serial)
-		return
-	}
-
-	t := m.Type()
-	vs := msg.Body
-	pointers := make([]interface{}, t.NumIn())
-	decode := make([]interface{}, 0, len(vs))
-	for i := 0; i < t.NumIn(); i++ {
-		tp := t.In(i)
+	for i := 0; i < m.NumArguments(); i++ {
+		tp := reflect.TypeOf(m.ArgumentValue(i))
 		val := reflect.New(tp)
 		pointers[i] = val.Interface()
 		if tp == reflect.TypeOf((*Sender)(nil)).Elem() {
@@ -197,26 +86,73 @@ func (conn *Conn) handleCall(msg *Message) {
 		}
 	}
 
-	if len(decode) != len(vs) {
-		conn.sendError(errmsgInvalidArg, sender, serial)
+	if len(decode) != len(body) {
+		return nil, ErrMsgInvalidArg
+	}
+
+	if err := Store(body, decode...); err != nil {
+		return nil, ErrMsgInvalidArg
+	}
+
+	return pointers, nil
+}
+
+func (conn *Conn) decodeArguments(m Method, sender string, msg *Message) ([]interface{}, error) {
+	if decoder, ok := m.(ArgumentDecoder); ok {
+		return decoder.DecodeArguments(conn, sender, msg, msg.Body)
+	}
+	return standardMethodArgumentDecode(m, sender, msg, msg.Body)
+}
+
+// handleCall handles the given method call (i.e. looks if it's one of the
+// pre-implemented ones and searches for a corresponding handler if not).
+func (conn *Conn) handleCall(msg *Message) {
+	name := msg.Headers[FieldMember].value.(string)
+	path := msg.Headers[FieldPath].value.(ObjectPath)
+	ifaceName, _ := msg.Headers[FieldInterface].value.(string)
+	sender, hasSender := msg.Headers[FieldSender].value.(string)
+	serial := msg.serial
+	if ifaceName == "org.freedesktop.DBus.Peer" {
+		switch name {
+		case "Ping":
+			conn.sendReply(sender, serial)
+		case "GetMachineId":
+			conn.sendReply(sender, serial, conn.uuid)
+		default:
+			conn.sendError(ErrMsgUnknownMethod, sender, serial)
+		}
+		return
+	}
+	if len(name) == 0 {
+		conn.sendError(ErrMsgUnknownMethod, sender, serial)
+	}
+
+	object, ok := conn.handler.LookupObject(path)
+	if !ok {
+		conn.sendError(ErrMsgNoObject, sender, serial)
 		return
 	}
 
-	if err := Store(vs, decode...); err != nil {
-		conn.sendError(errmsgInvalidArg, sender, serial)
+	iface, exists := object.LookupInterface(ifaceName)
+	if !exists {
+		conn.sendError(ErrMsgUnknownInterface, sender, serial)
 		return
 	}
 
-	// Extract parameters
-	params := make([]reflect.Value, len(pointers))
-	for i := 0; i < len(pointers); i++ {
-		params[i] = reflect.ValueOf(pointers[i]).Elem()
+	m, exists := iface.LookupMethod(name)
+	if !exists {
+		conn.sendError(ErrMsgUnknownMethod, sender, serial)
+		return
+	}
+	args, err := conn.decodeArguments(m, sender, msg)
+	if err != nil {
+		conn.sendError(err, sender, serial)
+		return
 	}
 
-	// Call method
-	ret := m.Call(params)
-	if em := ret[t.NumOut()-1].Interface().(*Error); em != nil {
-		conn.sendError(*em, sender, serial)
+	ret, err := m.Call(args...)
+	if err != nil {
+		conn.sendError(err, sender, serial)
 		return
 	}
 
@@ -229,13 +165,11 @@ func (conn *Conn) handleCall(msg *Message) {
 			reply.Headers[FieldDestination] = msg.Headers[FieldSender]
 		}
 		reply.Headers[FieldReplySerial] = MakeVariant(msg.serial)
-		reply.Body = make([]interface{}, len(ret)-1)
-		for i := 0; i < len(ret)-1; i++ {
-			reply.Body[i] = ret[i].Interface()
+		reply.Body = make([]interface{}, len(ret))
+		for i := 0; i < len(ret); i++ {
+			reply.Body[i] = ret[i]
 		}
-		if len(ret) != 1 {
-			reply.Headers[FieldSignature] = MakeVariant(SignatureOf(reply.Body...))
-		}
+		reply.Headers[FieldSignature] = MakeVariant(SignatureOf(reply.Body...))
 		conn.outLck.RLock()
 		if !conn.closed {
 			conn.out <- reply
@@ -375,7 +309,7 @@ func (conn *Conn) exportMethodTable(methods map[string]interface{}, path ObjectP
 		t := rval.Type()
 		// only track valid methods must return *Error as last arg
 		if t.NumOut() == 0 ||
-			t.Out(t.NumOut()-1) != reflect.TypeOf(&errmsgInvalidArg) {
+			t.Out(t.NumOut()-1) != reflect.TypeOf(&ErrMsgInvalidArg) {
 			continue
 		}
 		out[name] = rval
@@ -383,38 +317,49 @@ func (conn *Conn) exportMethodTable(methods map[string]interface{}, path ObjectP
 	return conn.export(out, path, iface, includeSubtree)
 }
 
+func (conn *Conn) unexport(h *defaultHandler, path ObjectPath, iface string) error {
+	if h.PathExists(path) {
+		obj := h.objects[path]
+		obj.DeleteInterface(iface)
+		if len(obj.interfaces) == 0 {
+			h.DeleteObject(path)
+		}
+	}
+	return nil
+}
+
 // exportWithMap is the worker function for all exports/registrations.
 func (conn *Conn) export(methods map[string]reflect.Value, path ObjectPath, iface string, includeSubtree bool) error {
+	h, ok := conn.handler.(*defaultHandler)
+	if !ok {
+		return fmt.Errorf(
+			`dbus: export only allowed on the default hander handler have %T"`,
+			conn.handler)
+	}
+
 	if !path.IsValid() {
 		return fmt.Errorf(`dbus: Invalid path name: "%s"`, path)
 	}
 
-	conn.handlersLck.Lock()
-	defer conn.handlersLck.Unlock()
-
 	// Remove a previous export if the interface is nil
 	if methods == nil {
-		if _, ok := conn.handlers[path]; ok {
-			delete(conn.handlers[path], iface)
-			if len(conn.handlers[path]) == 0 {
-				delete(conn.handlers, path)
-			}
-		}
-
-		return nil
+		return conn.unexport(h, path, iface)
 	}
 
 	// If this is the first handler for this path, make a new map to hold all
 	// handlers for this path.
-	if _, ok := conn.handlers[path]; !ok {
-		conn.handlers[path] = make(map[string]exportedObj)
+	if !h.PathExists(path) {
+		h.AddObject(path, newExportedObject())
+	}
+
+	exportedMethods := make(map[string]Method)
+	for name, method := range methods {
+		exportedMethods[name] = exportedMethod{method}
 	}
 
 	// Finally, save this handler
-	conn.handlers[path][iface] = exportedObj{
-		methods:        methods,
-		includeSubtree: includeSubtree,
-	}
+	obj := h.objects[path]
+	obj.AddInterface(iface, newExportedIntf(exportedMethods, includeSubtree))
 
 	return nil
 }

--- a/server_interfaces.go
+++ b/server_interfaces.go
@@ -1,0 +1,89 @@
+package dbus
+
+// Terminator allows a handler to implement a shutdown mechanism that
+// is called when the connection terminates.
+type Terminator interface {
+	Terminate()
+}
+
+// Handler is the representation of a D-Bus Application.
+//
+// The Handler must have a way to lookup objects given
+// an ObjectPath. The returned object must implement the
+// ServerObject interface.
+type Handler interface {
+	LookupObject(path ObjectPath) (ServerObject, bool)
+}
+
+// ServerObject is the representation of an D-Bus Object.
+//
+// Objects are registered at a path for a given Handler.
+// The Objects implement D-Bus interfaces. The semantics
+// of Interface lookup is up to the implementation of
+// the ServerObject. The ServerObject implementation may
+// choose to implement empty string as a valid interface
+// represeting all methods or not per the D-Bus specification.
+type ServerObject interface {
+	LookupInterface(name string) (Interface, bool)
+}
+
+// An Interface is the representation of a D-Bus Interface.
+//
+// Interfaces are a grouping of methods implemented by the Objects.
+// Interfaces are responsible for routing method calls.
+type Interface interface {
+	LookupMethod(name string) (Method, bool)
+}
+
+// A Method represents the exposed methods on D-Bus.
+type Method interface {
+	// Call requires that all arguments are decoded before being passed to it.
+	Call(args ...interface{}) ([]interface{}, error)
+	NumArguments() int
+	NumReturns() int
+	// ArgumentValue returns a representative value for the argument at position
+	// it should be of the proper type. reflect.Zero would be a good mechanism
+	// to use for this Value.
+	ArgumentValue(position int) interface{}
+	// ReturnValue returns a representative value for the return at position
+	// it should be of the proper type. reflect.Zero would be a good mechanism
+	// to use for this Value.
+	ReturnValue(position int) interface{}
+}
+
+// An Argument Decoder can decode arguments using the non-standard mechanism
+//
+// If a method implements this interface then the non-standard
+// decoder will be used.
+//
+// Method arguments must be decoded from the message.
+// The mechanism for doing this will vary based on the
+// implementation of the method. A normal approach is provided
+// as part of this library, but may be replaced with
+// any other decoding scheme.
+type ArgumentDecoder interface {
+	// To decode the arguments of a method the sender and message are
+	// provided incase the semantics of the implementer provides access
+	// to these as part of the method invocation.
+	DecodeArguments(conn *Conn, sender string, msg *Message, args []interface{}) ([]interface{}, error)
+}
+
+// A SignalHandler is responsible for delivering a signal.
+//
+// Signal delivery may be changed from the default channel
+// based approach by Handlers implementing the SignalHandler
+// interface.
+type SignalHandler interface {
+	DeliverSignal(iface, name string, signal *Signal)
+}
+
+// A DBusError is used to convert a generic object to a D-Bus error.
+//
+// Any custom error mechanism may implement this interface to provide
+// a custom encoding of the error on D-Bus. By default if a normal
+// error is returned, it will be encoded as the generic
+// "org.freedesktop.DBus.Error.Failed" error. By implementing this
+// interface as well a custom encoding may be provided.
+type DBusError interface {
+	DBusError() *Error
+}

--- a/server_interfaces_test.go
+++ b/server_interfaces_test.go
@@ -1,0 +1,370 @@
+package dbus
+
+import (
+	"testing"
+	"time"
+)
+
+type tester struct {
+	conn    *Conn
+	sigs    chan *Signal
+	subSigs map[string]map[string]struct{}
+}
+
+type intro struct {
+	path ObjectPath
+}
+
+func (i *intro) introspectPath(path ObjectPath) string {
+	switch path {
+	case "/":
+		return `<node><node name="com"></node></node>`
+	case "/com":
+		return `<node><node name="github"></node></node>`
+	case "/com/github":
+		return `<node><node name="godbus"></node></node>`
+	case "/com/github/godbus":
+		return `<node><node name="tester"></node></node>`
+	}
+	return ""
+}
+
+func (i *intro) LookupInterface(name string) (Interface, bool) {
+	if name == "org.freedesktop.DBus.Introspectable" {
+		return i, true
+	}
+	return nil, false
+}
+
+func (i *intro) LookupMethod(name string) (Method, bool) {
+	if name == "Introspect" {
+		return intro_fn(func() string {
+			return i.introspectPath(i.path)
+		}), true
+	}
+	return nil, false
+}
+
+func newIntro(path ObjectPath) *intro {
+	return &intro{path}
+}
+
+//Handler
+func (t *tester) LookupObject(path ObjectPath) (ServerObject, bool) {
+	if path == "/com/github/godbus/tester" {
+		return t, true
+	}
+	return newIntro(path), true
+}
+
+//ServerObject
+func (t *tester) LookupInterface(name string) (Interface, bool) {
+	switch name {
+	case "com.github.godbus.dbus.Tester":
+		return t, true
+	case "org.freedesktop.DBus.Introspectable":
+		return t, true
+	}
+
+	return nil, false
+}
+
+//Interface
+func (t *tester) LookupMethod(name string) (Method, bool) {
+	switch name {
+	case "Test":
+		return t, true
+	case "Introspect":
+		return intro_fn(func() string {
+			return `<node>
+    <interface name="org.freedesktop.DBus.Introspectable.Introspect">
+        <method name="Introspect">
+            <arg name="out" type="i" direction="out">
+        </method>
+    </interface>
+    <interface name="com.github.godbus.dbus.Tester">
+        <method name="Test">
+            <arg name="in" type="i" direction="in">
+            <arg name="out" type="i" direction="out">
+        </method>
+        <signal name="sig1">
+            <arg name="out" type="i" direction="out">
+        </signal>
+    </interface>
+</node>`
+		}), true
+	}
+	return nil, false
+}
+
+//Method
+func (t *tester) Call(args ...interface{}) ([]interface{}, error) {
+	return args, nil
+}
+
+func (t *tester) NumArguments() int {
+	return 1
+}
+
+func (t *tester) NumReturns() int {
+	return 1
+}
+
+func (t *tester) ArgumentValue(position int) interface{} {
+	return ""
+}
+
+func (t *tester) ReturnValue(position int) interface{} {
+	return ""
+}
+
+//SignalHandler
+func (t *tester) DeliverSignal(iface, name string, signal *Signal) {
+	intf, ok := t.subSigs[iface]
+	if !ok {
+		return
+	}
+	if _, ok := intf[name]; !ok {
+		return
+	}
+	t.sigs <- signal
+}
+
+func (t *tester) AddSignal(iface, name string) {
+	if i, ok := t.subSigs[iface]; ok {
+		i[name] = struct{}{}
+	} else {
+		t.subSigs[iface] = make(map[string]struct{})
+		t.subSigs[iface][name] = struct{}{}
+	}
+	t.conn.BusObject().(*Object).AddMatchSignal(
+		iface, name)
+}
+
+func (t *tester) Close() {
+	t.conn.Close()
+	close(t.sigs)
+}
+
+func (t *tester) Name() string {
+	return t.conn.Names()[0]
+}
+
+type intro_fn func() string
+
+func (intro intro_fn) Call(args ...interface{}) ([]interface{}, error) {
+	return []interface{}{intro()}, nil
+}
+
+func (_ intro_fn) NumArguments() int {
+	return 0
+}
+
+func (_ intro_fn) NumReturns() int {
+	return 1
+}
+
+func (_ intro_fn) ArgumentValue(position int) interface{} {
+	return nil
+}
+
+func (_ intro_fn) ReturnValue(position int) interface{} {
+	return ""
+}
+
+func newTester() (*tester, error) {
+	tester := &tester{
+		sigs:    make(chan *Signal),
+		subSigs: make(map[string]map[string]struct{}),
+	}
+	conn, err := SessionBusPrivateHandler(tester, tester)
+	if err != nil {
+		return nil, err
+	}
+	err = conn.Auth(nil)
+	if err != nil {
+		conn.Close()
+		return nil, err
+	}
+	err = conn.Hello()
+	if err != nil {
+		conn.Close()
+		return nil, err
+	}
+	tester.conn = conn
+	return tester, nil
+}
+
+func TestHandlerCall(t *testing.T) {
+	tester, err := newTester()
+	if err != nil {
+		t.Errorf("Unexpected error: %s", err)
+	}
+	conn, err := SessionBus()
+	if err != nil {
+		t.Errorf("Unexpected error: %s", err)
+	}
+	obj := conn.Object(tester.Name(), "/com/github/godbus/tester")
+	var out string
+	in := "foo"
+	err = obj.Call("com.github.godbus.dbus.Tester.Test", 0, in).Store(&out)
+	if err != nil {
+		t.Errorf("Unexpected error: %s", err)
+	}
+	if out != in {
+		t.Errorf("Unexpected error: got %s, expected %s", out, in)
+	}
+	tester.Close()
+}
+
+func TestHandlerCallNonExistent(t *testing.T) {
+	tester, err := newTester()
+	if err != nil {
+		t.Errorf("Unexpected error: %s", err)
+	}
+	conn, err := SessionBus()
+	if err != nil {
+		t.Errorf("Unexpected error: %s", err)
+	}
+	obj := conn.Object(tester.Name(), "/com/github/godbus/tester/nonexist")
+	var out string
+	in := "foo"
+	err = obj.Call("com.github.godbus.dbus.Tester.Test", 0, in).Store(&out)
+	if err != nil {
+		if err.Error() != "Object does not implement the interface" {
+			t.Errorf("Unexpected error: %s", err)
+		}
+	}
+	tester.Close()
+}
+
+func TestHandlerInvalidFunc(t *testing.T) {
+	tester, err := newTester()
+	if err != nil {
+		t.Errorf("Unexpected error: %s", err)
+	}
+	conn, err := SessionBus()
+	if err != nil {
+		t.Errorf("Unexpected error: %s", err)
+	}
+	obj := conn.Object(tester.Name(), "/com/github/godbus/tester")
+	var out string
+	in := "foo"
+	err = obj.Call("com.github.godbus.dbus.Tester.Notexist", 0, in).Store(&out)
+	if err == nil {
+		t.Errorf("didn't get expected error")
+	}
+	tester.Close()
+}
+
+func TestHandlerInvalidNumArg(t *testing.T) {
+	tester, err := newTester()
+	if err != nil {
+		t.Errorf("Unexpected error: %s", err)
+	}
+	conn, err := SessionBus()
+	if err != nil {
+		t.Errorf("Unexpected error: %s", err)
+	}
+	obj := conn.Object(tester.Name(), "/com/github/godbus/tester")
+	var out string
+	err = obj.Call("com.github.godbus.dbus.Tester.Test", 0).Store(&out)
+	if err == nil {
+		t.Errorf("didn't get expected error")
+	}
+	tester.Close()
+}
+
+func TestHandlerInvalidArgType(t *testing.T) {
+	tester, err := newTester()
+	if err != nil {
+		t.Errorf("Unexpected error: %s", err)
+	}
+	conn, err := SessionBus()
+	if err != nil {
+		t.Errorf("Unexpected error: %s", err)
+	}
+	obj := conn.Object(tester.Name(), "/com/github/godbus/tester")
+	var out string
+	err = obj.Call("com.github.godbus.dbus.Tester.Test", 0, 2.10).Store(&out)
+	if err == nil {
+		t.Errorf("didn't get expected error")
+	}
+	tester.Close()
+}
+
+func TestHandlerIntrospect(t *testing.T) {
+	tester, err := newTester()
+	if err != nil {
+		t.Errorf("Unexpected error: %s", err)
+	}
+	conn, err := SessionBus()
+	if err != nil {
+		t.Errorf("Unexpected error: %s", err)
+	}
+	obj := conn.Object(tester.Name(), "/com/github/godbus/tester")
+	var out string
+	err = obj.Call("org.freedesktop.DBus.Introspectable.Introspect", 0).Store(&out)
+	expected := `<node>
+    <interface name="org.freedesktop.DBus.Introspectable.Introspect">
+        <method name="Introspect">
+            <arg name="out" type="i" direction="out">
+        </method>
+    </interface>
+    <interface name="com.github.godbus.dbus.Tester">
+        <method name="Test">
+            <arg name="in" type="i" direction="in">
+            <arg name="out" type="i" direction="out">
+        </method>
+        <signal name="sig1">
+            <arg name="out" type="i" direction="out">
+        </signal>
+    </interface>
+</node>`
+	if out != expected {
+		t.Errorf("didn't get expected return value, expected %s got %s", expected, out)
+	}
+	tester.Close()
+}
+
+func TestHandlerIntrospectPath(t *testing.T) {
+	tester, err := newTester()
+	if err != nil {
+		t.Errorf("Unexpected error: %s", err)
+	}
+	conn, err := SessionBus()
+	if err != nil {
+		t.Errorf("Unexpected error: %s", err)
+	}
+	obj := conn.Object(tester.Name(), "/com/github/godbus")
+	var out string
+	err = obj.Call("org.freedesktop.DBus.Introspectable.Introspect", 0).Store(&out)
+	expected := `<node><node name="tester"></node></node>`
+	if out != expected {
+		t.Errorf("didn't get expected return value, expected %s got %s", expected, out)
+	}
+	tester.Close()
+}
+
+func TestHandlerSignal(t *testing.T) {
+	tester, err := newTester()
+	if err != nil {
+		t.Errorf("Unexpected error: %s", err)
+	}
+	conn, err := SessionBus()
+	if err != nil {
+		t.Errorf("Unexpected error: %s", err)
+	}
+	tester.AddSignal("com.github.godbus.dbus.Tester", "sig1")
+	conn.Emit("/com/github/godbus/tester",
+		"com.github.godbus.dbus.Tester.sig1", "foo")
+	select {
+	case sig := <-tester.sigs:
+		if sig.Body[0] != "foo" {
+			t.Errorf("Unexpected signal got %s, expected %s", sig.Body[0], "foo")
+		}
+	case <-time.After(time.Second * 10): //overly generous timeout
+		t.Errorf("Didn't receive a signal after 10 seconds")
+	}
+	tester.Close()
+}


### PR DESCRIPTION
This refactor allows for all the details of connection message
handling to be overridden. The previously inline handlers for signals
and messages are now implemented as an instance of the interfaces.

This is useful for substituting the default object model for another
model allowing full customization of object and method lookup. This
allows for higher level abstractions to be built without breaking
compatibility with the current library.

All '*Conn' Export and Signal registration will only work with these
default handlers. It is expected that implementations wishing to
override the behavior of method lookup and signal delivery will
implement similar mechanisms. The details of what can be exported or
how a signal should be delivered are up to the implementation of the
interface and thus should not be part of the interface definition.
