### PR TITLE
Only launch one D-Bus instance

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -16,6 +16,7 @@ var (
 	systemBusLck  sync.Mutex
 	sessionBus    *Conn
 	sessionBusLck sync.Mutex
+	sessionEnvLck sync.Mutex
 )
 
 // ErrClosed is the error returned by calls on a closed connection.
@@ -91,6 +92,8 @@ func SessionBus() (conn *Conn, err error) {
 
 // SessionBusPrivate returns a new private connection to the session bus.
 func SessionBusPrivate() (*Conn, error) {
+	sessionEnvLck.Lock()
+	defer sessionEnvLck.Unlock()
 	address := os.Getenv("DBUS_SESSION_BUS_ADDRESS")
 	if address != "" && address != "autolaunch:" {
 		return Dial(address)

--- a/conn_other.go
+++ b/conn_other.go
@@ -5,6 +5,7 @@ package dbus
 import (
 	"bytes"
 	"errors"
+	"os"
 	"os/exec"
 )
 
@@ -23,5 +24,8 @@ func sessionBusPlatform() (*Conn, error) {
 		return nil, errors.New("dbus: couldn't determine address of session bus")
 	}
 
-	return Dial(string(b[i+1 : j]))
+	env, addr := string(b[0:i]), string(b[i+1:j])
+	os.Setenv(env, addr)
+
+	return Dial(addr)
 }


### PR DESCRIPTION
This ensures that only one D-Bus instance is started and shared by
all connections when a D-Bus instance doesn't exist in the environment
under which the program was started.

Fixes #61