### PR TITLE
dbus: Only dereference dest in store if Kind is Interface or Ptr

### DIFF
--- a/dbus.go
+++ b/dbus.go
@@ -58,7 +58,10 @@ func store(src, dest interface{}) error {
 		reflect.ValueOf(dest).Elem().Set(reflect.ValueOf(src))
 		return nil
 	} else if hasStruct(dest) {
-		rv := reflect.ValueOf(dest).Elem()
+		rv := reflect.ValueOf(dest)
+		if rv.Kind() == reflect.Interface || rv.Kind() == reflect.Ptr {
+			rv = rv.Elem()
+		}
 		switch rv.Kind() {
 		case reflect.Struct:
 			vs, ok := src.([]interface{})


### PR DESCRIPTION
Trying to store the result of a call with a signature like like `a{sa{sv}}` to a `map[string]map[string]Variant` panics due to trying to call `Elem()` on a Map Value.

Only call `Elem()` when the destination value is of Kind Interface or Ptr.

[NetworkManager](https://developer.gnome.org/NetworkManager/0.9/spec.html#org.freedesktop.NetworkManager.Settings.Connection.GetSettings) has an example of such a method.