### PR TITLE
Add support for mapping the empty interface to Variants where appropriate

### DIFF
--- a/dbus.go
+++ b/dbus.go
@@ -58,71 +58,179 @@ func store(src, dest interface{}) error {
 		reflect.ValueOf(dest).Elem().Set(reflect.ValueOf(src))
 		return nil
 	} else if hasStruct(dest) {
-		rv := reflect.ValueOf(dest)
-		if rv.Kind() == reflect.Interface || rv.Kind() == reflect.Ptr {
-			rv = rv.Elem()
-		}
-		switch rv.Kind() {
-		case reflect.Struct:
-			vs, ok := src.([]interface{})
-			if !ok {
-				return errors.New("dbus.Store: type mismatch")
-			}
-			t := rv.Type()
-			ndest := make([]interface{}, 0, rv.NumField())
-			for i := 0; i < rv.NumField(); i++ {
-				field := t.Field(i)
-				if field.PkgPath == "" && field.Tag.Get("dbus") != "-" {
-					ndest = append(ndest, rv.Field(i).Addr().Interface())
-				}
-			}
-			if len(vs) != len(ndest) {
-				return errors.New("dbus.Store: type mismatch")
-			}
-			err := Store(vs, ndest...)
-			if err != nil {
-				return errors.New("dbus.Store: type mismatch")
-			}
-		case reflect.Slice:
-			sv := reflect.ValueOf(src)
-			if sv.Kind() != reflect.Slice {
-				return errors.New("dbus.Store: type mismatch")
-			}
-			rv.Set(reflect.MakeSlice(rv.Type(), sv.Len(), sv.Len()))
-			for i := 0; i < sv.Len(); i++ {
-				if err := store(sv.Index(i).Interface(), rv.Index(i).Addr().Interface()); err != nil {
-					return err
-				}
-			}
-		case reflect.Map:
-			sv := reflect.ValueOf(src)
-			if sv.Kind() != reflect.Map {
-				return errors.New("dbus.Store: type mismatch")
-			}
-			keys := sv.MapKeys()
-			rv.Set(reflect.MakeMap(sv.Type()))
-			for _, key := range keys {
-				v := reflect.New(sv.Type().Elem())
-				if err := store(v, sv.MapIndex(key).Interface()); err != nil {
-					return err
-				}
-				rv.SetMapIndex(key, v.Elem())
-			}
-		default:
-			return errors.New("dbus.Store: type mismatch")
-		}
-		return nil
+		return storeStruct(src, dest)
+	} else if hasInterface(dest) {
+		return storeInterfaceContainer(src, dest)
 	} else {
 		return errors.New("dbus.Store: type mismatch")
 	}
 }
 
+func storeStruct(src, dest interface{}) error {
+	rv := reflect.ValueOf(dest)
+	if rv.Kind() == reflect.Interface || rv.Kind() == reflect.Ptr {
+		rv = rv.Elem()
+	}
+	switch rv.Kind() {
+	case reflect.Struct:
+		vs, ok := src.([]interface{})
+		if !ok {
+			return errors.New("dbus.Store: type mismatch")
+		}
+		t := rv.Type()
+		ndest := make([]interface{}, 0, rv.NumField())
+		for i := 0; i < rv.NumField(); i++ {
+			field := t.Field(i)
+			if field.PkgPath == "" && field.Tag.Get("dbus") != "-" {
+				ndest = append(ndest, rv.Field(i).Addr().Interface())
+
+			}
+		}
+		if len(vs) != len(ndest) {
+			return errors.New("dbus.Store: type mismatch")
+		}
+		err := Store(vs, ndest...)
+		if err != nil {
+			return errors.New("dbus.Store: type mismatch")
+		}
+	case reflect.Slice:
+		sv := reflect.ValueOf(src)
+		if sv.Kind() != reflect.Slice {
+			return errors.New("dbus.Store: type mismatch")
+		}
+		rv.Set(reflect.MakeSlice(rv.Type(), sv.Len(), sv.Len()))
+		for i := 0; i < sv.Len(); i++ {
+			if err := store(sv.Index(i).Interface(), rv.Index(i).Addr().Interface()); err != nil {
+				return err
+			}
+		}
+	case reflect.Map:
+		sv := reflect.ValueOf(src)
+		if sv.Kind() != reflect.Map {
+			return errors.New("dbus.Store: type mismatch")
+		}
+		keys := sv.MapKeys()
+		rv.Set(reflect.MakeMap(sv.Type()))
+		for _, key := range keys {
+			v := reflect.New(sv.Type().Elem())
+			if err := store(v, sv.MapIndex(key).Interface()); err != nil {
+				return err
+			}
+			rv.SetMapIndex(key, v.Elem())
+		}
+	default:
+		return errors.New("dbus.Store: type mismatch")
+	}
+	return nil
+}
+
+func storeInterfaceContainer(src, dest interface{}) error {
+	rv := reflect.ValueOf(dest).Elem()
+	switch rv.Kind() {
+	case reflect.Interface:
+		return storeInterfaceValue(src, dest)
+	case reflect.Slice:
+		sv := reflect.ValueOf(src)
+		if sv.Kind() != reflect.Slice {
+			return errors.New("dbus.Store: type mismatch")
+		}
+		rv.Set(reflect.MakeSlice(rv.Type(), sv.Len(), sv.Len()))
+		for i := 0; i < sv.Len(); i++ {
+			v := newInterfaceImplValue(sv.Index(i))
+			err := store(getVariantValue(sv.Index(i)),
+				v.Interface())
+			if err != nil {
+				return err
+			}
+			rv.Index(i).Set(v.Elem())
+		}
+	case reflect.Map:
+		sv := reflect.ValueOf(src)
+		if sv.Kind() != reflect.Map {
+			return errors.New("dbus.Store: type mismatch")
+		}
+		keys := sv.MapKeys()
+		rv.Set(reflect.MakeMap(rv.Type()))
+		for _, key := range keys {
+			elemv := sv.MapIndex(key)
+			v := newInterfaceImplValue(elemv)
+			err := store(getVariantValue(elemv),
+				v.Interface())
+			if err != nil {
+				return err
+			}
+			rv.SetMapIndex(key, v.Elem())
+		}
+	default:
+		return errors.New("dbus.Store: type mismatch")
+	}
+	return nil
+}
+
+func getVariantValue(in reflect.Value) interface{} {
+	if in.Type() == variantType {
+		return in.Interface().(Variant).Value()
+	}
+	return in.Interface()
+}
+
+func newInterfaceImplValue(val reflect.Value) reflect.Value {
+	ifaceType := reflect.TypeOf((*interface{})(nil)).Elem()
+	if !hasVariant(val.Type()) {
+		return reflect.New(val.Type())
+	}
+	switch val.Kind() {
+	case reflect.Map:
+		return reflect.New(reflect.MapOf(val.Type().Key(),
+			ifaceType))
+	case reflect.Slice:
+		return reflect.New(reflect.SliceOf(ifaceType))
+	default:
+		return newInterfaceImplValue(
+			reflect.ValueOf(
+				val.Interface().(Variant).Value()))
+	}
+}
+
+func storeInterfaceValue(src, dest interface{}) error {
+	sv := reflect.ValueOf(src)
+	if sv.Type() == variantType {
+		store(src.(Variant).Value(), dest)
+	} else {
+		reflect.ValueOf(dest).Elem().Set(
+			reflect.ValueOf(src))
+	}
+	return nil
+}
+
 func hasStruct(v interface{}) bool {
+	return hasKind(v, reflect.Struct)
+}
+
+func hasInterface(v interface{}) bool {
+	return hasKind(v, reflect.Interface)
+}
+
+func hasKind(v interface{}, kind reflect.Kind) bool {
 	t := reflect.TypeOf(v)
 	for {
 		switch t.Kind() {
-		case reflect.Struct:
+		case kind:
 			return true
+		case reflect.Slice, reflect.Ptr, reflect.Map:
+			t = t.Elem()
+		default:
+			return false
+		}
+	}
+}
+
+func hasVariant(t reflect.Type) bool {
+	for {
+		if t == variantType {
+			return true
+		}
+		switch t.Kind() {
 		case reflect.Slice, reflect.Ptr, reflect.Map:
 			t = t.Elem()
 		default:
@@ -180,8 +288,8 @@ func alignment(t reflect.Type) int {
 		return 4
 	case signatureType:
 		return 1
-	case interfacesType: // sometimes used for structs
-		return 8
+	case interfacesType:
+		return 4
 	}
 	switch t.Kind() {
 	case reflect.Uint8:

--- a/encoder.go
+++ b/encoder.go
@@ -202,6 +202,8 @@ func (enc *encoder) encode(v reflect.Value, depth int) {
 			panic(err)
 		}
 		enc.pos += length
+	case reflect.Interface:
+		enc.encode(reflect.ValueOf(MakeVariant(v.Interface())), depth)
 	default:
 		panic(InvalidTypeError{v.Type()})
 	}

--- a/encoder_test.go
+++ b/encoder_test.go
@@ -56,3 +56,82 @@ func TestEncodeArrayOfMaps(t *testing.T) {
 		}
 	}
 }
+
+func TestEncodeMapStringInterface(t *testing.T) {
+	val := map[string]interface{}{"foo": "bar"}
+	buf := new(bytes.Buffer)
+	order := binary.LittleEndian
+	enc := newEncoder(buf, binary.LittleEndian)
+	err := enc.Encode(val)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	dec := newDecoder(buf, order)
+	v, err := dec.Decode(SignatureOf(val))
+	if err != nil {
+		t.Fatal(err)
+	}
+	out := map[string]interface{}{}
+	Store(v, &out)
+	if !reflect.DeepEqual(out, val) {
+		t.Errorf("not equal: got '%v', want '%v'",
+			out, val)
+	}
+}
+
+func TestEncodeSliceInterface(t *testing.T) {
+	val := []interface{}{"foo", "bar"}
+	buf := new(bytes.Buffer)
+	order := binary.LittleEndian
+	enc := newEncoder(buf, binary.LittleEndian)
+	err := enc.Encode(val)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	dec := newDecoder(buf, order)
+	v, err := dec.Decode(SignatureOf(val))
+	if err != nil {
+		t.Fatal(err)
+	}
+	out := []interface{}{}
+	Store(v, &out)
+	if !reflect.DeepEqual(out, val) {
+		t.Errorf("not equal: got '%v', want '%v'",
+			out, val)
+	}
+}
+
+func TestEncodeNestedInterface(t *testing.T) {
+	val := map[string]interface{}{
+		"foo": []interface{}{"1", "2", "3", "5",
+			map[string]interface{}{
+				"bar": "baz",
+			},
+		},
+		"bar": map[string]interface{}{
+			"baz":  "quux",
+			"quux": "quuz",
+		},
+	}
+	buf := new(bytes.Buffer)
+	order := binary.LittleEndian
+	enc := newEncoder(buf, binary.LittleEndian)
+	err := enc.Encode(val)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	dec := newDecoder(buf, order)
+	v, err := dec.Decode(SignatureOf(val))
+	if err != nil {
+		t.Fatal(err)
+	}
+	out := map[string]interface{}{}
+	Store(v, &out)
+	if !reflect.DeepEqual(out, val) {
+		t.Errorf("not equal: got '%v', want '%v'",
+			out, val)
+	}
+}

--- a/sig.go
+++ b/sig.go
@@ -101,6 +101,8 @@ func getSignature(t reflect.Type) string {
 			panic(InvalidTypeError{t})
 		}
 		return "a{" + getSignature(t.Key()) + getSignature(t.Elem()) + "}"
+	case reflect.Interface:
+		return "v"
 	}
 	panic(InvalidTypeError{t})
 }

--- a/store_test.go
+++ b/store_test.go
@@ -1,0 +1,99 @@
+package dbus
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestStoreStringToInterface(t *testing.T) {
+	var dest interface{}
+	err := Store([]interface{}{"foobar"}, &dest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = dest.(string)
+}
+
+func TestStoreVariantToInterface(t *testing.T) {
+	src := MakeVariant("foobar")
+	var dest interface{}
+	err := Store([]interface{}{src}, &dest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = dest.(string)
+}
+
+func TestStoreMapStringToMapInterface(t *testing.T) {
+	src := map[string]string{"foo": "bar"}
+	dest := map[string]interface{}{}
+	err := Store([]interface{}{src}, &dest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = dest["foo"].(string)
+}
+
+func TestStoreMapVariantToMapInterface(t *testing.T) {
+	src := map[string]Variant{"foo": MakeVariant("foobar")}
+	dest := map[string]interface{}{}
+	err := Store([]interface{}{src}, &dest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = dest["foo"].(string)
+}
+
+func TestStoreSliceStringToSliceInterface(t *testing.T) {
+	src := []string{"foo"}
+	dest := []interface{}{}
+	err := Store([]interface{}{src}, &dest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = dest[0].(string)
+}
+
+func TestStoreSliceVariantToSliceInterface(t *testing.T) {
+	src := []Variant{MakeVariant("foo")}
+	dest := []interface{}{}
+	err := Store([]interface{}{src}, &dest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = dest[0].(string)
+}
+
+func TestStoreSliceVariantToSliceInterfaceMulti(t *testing.T) {
+	src := []Variant{MakeVariant("foo"), MakeVariant(int32(1))}
+	dest := []interface{}{}
+	err := Store([]interface{}{src}, &dest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = dest[0].(string)
+	_ = dest[1].(int32)
+}
+
+func TestStoreNested(t *testing.T) {
+	src := map[string]interface{}{
+		"foo": []interface{}{"1", "2", "3", "5",
+			map[string]interface{}{
+				"bar": "baz",
+			},
+		},
+		"bar": map[string]interface{}{
+			"baz":  "quux",
+			"quux": "quuz",
+		},
+	}
+	dest := map[string]interface{}{}
+	err := Store([]interface{}{src}, &dest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(src, dest) {
+		t.Errorf("not equal: got '%v', want '%v'",
+			dest, src)
+	}
+}


### PR DESCRIPTION

It is appropriate to convert emtpy interface to Variant in the following
situations:
  a) Standalone empty interface as dest in Store.
  b) []interface{} as dest in Store.
  c) map[T]interface{} as dest in Store.
  d) Signature "v" for empty interface type
  e) Encode of empty interface becomes encode of variant.

This commit also refactors Store to be more readable.

This addresses #70 