### PR TITLE
Fix generic error handling

### DIFF
--- a/export.go
+++ b/export.go
@@ -29,7 +29,7 @@ var (
 func MakeFailedError(err error) *Error {
 	return &Error{
 		"org.freedesktop.DBus.Error.Failed",
-		[]interface{}{err},
+		[]interface{}{err.Error()},
 	}
 }
 


### PR DESCRIPTION
When encoding a generic error the error needs to be resolved to a
string so that the encoder can encode it properly. Currently if a
generic error of the wrong type is used the D-Bus connection will
be silently terminated. This fixes #73.