### PR TITLE
Change the DBusError interface

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -512,7 +512,8 @@ func (conn *Conn) sendError(err error, dest string, serial uint32) {
 	case *Error:
 		e = em
 	case DBusError:
-		e = em.DBusError()
+		name, body := em.DBusError()
+		e = NewError(name, body)
 	default:
 		e = MakeFailedError(err)
 	}

--- a/server_interfaces.go
+++ b/server_interfaces.go
@@ -85,5 +85,5 @@ type SignalHandler interface {
 // "org.freedesktop.DBus.Error.Failed" error. By implementing this
 // interface as well a custom encoding may be provided.
 type DBusError interface {
-	DBusError() *Error
+	DBusError() (string, []interface{})
 }


### PR DESCRIPTION
Since The DBusError interface requires one to return a concrete type
from the D-Bus library, that library must be imported by every thing
that returns one of these errors. It would be friendlier to support
returning base types so that the implementations need not import the
godbus library.

This is not compatible, but the interface is still fairly new.