### PR TITLE
Rework support for more go types.

### DIFF
--- a/encoder_test.go
+++ b/encoder_test.go
@@ -362,3 +362,53 @@ func TestEncodeVariant(t *testing.T) {
 	}
 	_ = res[ObjectPath("/foo/bar")]["foo"]["baz"].Value().(string)
 }
+
+func TestEncodeVariantToList(t *testing.T) {
+	var res map[string]Variant
+	var src = map[string]interface{}{
+		"foo": []interface{}{"a", "b", "c"},
+	}
+	buf := new(bytes.Buffer)
+	order := binary.LittleEndian
+	enc := newEncoder(buf, binary.LittleEndian)
+	err := enc.Encode(src)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	dec := newDecoder(buf, order)
+	v, err := dec.Decode(SignatureOf(src))
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = Store(v, &res)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = res["foo"].Value().([]Variant)
+}
+
+func TestEncodeVariantToUint64(t *testing.T) {
+	var res map[string]Variant
+	var src = map[string]interface{}{
+		"foo": uint64(10),
+	}
+	buf := new(bytes.Buffer)
+	order := binary.LittleEndian
+	enc := newEncoder(buf, binary.LittleEndian)
+	err := enc.Encode(src)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	dec := newDecoder(buf, order)
+	v, err := dec.Decode(SignatureOf(src))
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = Store(v, &res)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = res["foo"].Value().(uint64)
+}


### PR DESCRIPTION
The old algorithm iterated on the destination datastructures. This
meant that tricky look ahead was required to handle all cases. By
iterating on the source datastructure instead we can vastly simplify
the logic for converting a source type into a destination type.

This commit changes the type mismatch errors to indicate the actual
problem with the types.

Additional test cases now catch the problems seen by
coreos/go-systemd.

Fixes #80