### PR TITLE
make transport endian aware

### DIFF
--- a/transport_generic.go
+++ b/transport_generic.go
@@ -4,7 +4,22 @@ import (
 	"encoding/binary"
 	"errors"
 	"io"
+	"unsafe"
 )
+
+var nativeEndian binary.ByteOrder
+
+func detectEndianness() binary.ByteOrder {
+	var x uint32 = 0x01020304
+		if *(*byte)(unsafe.Pointer(&x)) == 0x01 {
+		return binary.BigEndian
+	}
+	return binary.LittleEndian
+}
+
+func init() {
+	nativeEndian = detectEndianness()
+}
 
 type genericTransport struct {
 	io.ReadWriteCloser
@@ -31,5 +46,5 @@ func (t genericTransport) SendMessage(msg *Message) error {
 			return errors.New("dbus: unix fd passing not enabled")
 		}
 	}
-	return msg.EncodeTo(t, binary.LittleEndian)
+	return msg.EncodeTo(t, nativeEndian)
 }

--- a/transport_unix.go
+++ b/transport_unix.go
@@ -175,7 +175,7 @@ func (t *unixTransport) SendMessage(msg *Message) error {
 		msg.Headers[FieldUnixFDs] = MakeVariant(uint32(len(fds)))
 		oob := syscall.UnixRights(fds...)
 		buf := new(bytes.Buffer)
-		msg.EncodeTo(buf, binary.LittleEndian)
+		msg.EncodeTo(buf, nativeEndian)
 		n, oobn, err := t.UnixConn.WriteMsgUnix(buf.Bytes(), oob, nil)
 		if err != nil {
 			return err
@@ -184,7 +184,7 @@ func (t *unixTransport) SendMessage(msg *Message) error {
 			return io.ErrShortWrite
 		}
 	} else {
-		if err := msg.EncodeTo(t, binary.LittleEndian); err != nil {
+		if err := msg.EncodeTo(t, nativeEndian); err != nil {
 			return nil
 		}
 	}


### PR DESCRIPTION
Introduce function NativeEndian() (borrowed from https://github.com/vishvananda/netlink/blob/master/nl/nl_linux.go#L45) that check the endianness of the host and set the correct value for the EncodeTo() function calls.

When we used this Go DBus library on a big endian machine (s390x) we saw "Operation not supported" error coming from https://github.com/systemd/systemd/blob/master/src/libsystemd/sd-bus/bus-message.c#L4803 because the messages were sent in little endian format.