### PR TITLE
Allow exposing methods without error return type

### DIFF
--- a/default_handler.go
+++ b/default_handler.go
@@ -130,12 +130,15 @@ func (m exportedMethod) Call(args ...interface{}) ([]interface{}, error) {
 		errorType := reflect.TypeOf((*error)(nil)).Elem()
 
 		if t.Out(numOut - 1).Implements(errorType) {
-			err = ret[numOut-1].Interface().(error)
+			if ret[numOut-1].IsNil() {
+				err = nil
+			} else {
+				err = ret[numOut-1].Interface().(error)
+			}
 
 			numOut -= 1
 		}
 	}
-
 
 	ret = ret[:numOut]
 	out := make([]interface{}, len(ret))
@@ -143,7 +146,7 @@ func (m exportedMethod) Call(args ...interface{}) ([]interface{}, error) {
 		out[i] = val.Interface()
 	}
 
-	if err == nil || reflect.ValueOf(err).IsNil() {
+	if err == nil {
 		//concrete type to interface nil is a special case
 		return out, nil
 	}

--- a/export.go
+++ b/export.go
@@ -55,12 +55,9 @@ func getMethods(in interface{}, mapping map[string]string) map[string]reflect.Va
 	for i := 0; i < typ.NumMethod(); i++ {
 		methtype := typ.Method(i)
 		method := val.Method(i)
-		t := method.Type()
 		// only track valid methods must return *Error as last arg
 		// and must be exported
-		if t.NumOut() == 0 ||
-			t.Out(t.NumOut()-1) != reflect.TypeOf(&ErrMsgInvalidArg) ||
-			methtype.PkgPath != "" {
+		if methtype.PkgPath != "" {
 			continue
 		}
 		// map names while building table
@@ -306,12 +303,7 @@ func (conn *Conn) exportMethodTable(methods map[string]interface{}, path ObjectP
 		if rval.Kind() != reflect.Func {
 			continue
 		}
-		t := rval.Type()
-		// only track valid methods must return *Error as last arg
-		if t.NumOut() == 0 ||
-			t.Out(t.NumOut()-1) != reflect.TypeOf(&ErrMsgInvalidArg) {
-			continue
-		}
+
 		out[name] = rval
 	}
 	return conn.export(out, path, iface, includeSubtree)


### PR DESCRIPTION
Currently only methods of an object that return the dbus.Error can be exposed directly on the bus. Other methods need a wrapper method to do so. This patch eliminates the need for the wrapper. This has been achieved by checking if the last output parameter of the method implements the error interface. If so the value returned by the function call is used as an error, else the method is assumed to not return any error. 