### PR TITLE
Allow implementations to decide when to make signal handling asynchronous.

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -368,7 +368,7 @@ func (conn *Conn) inWorker() {
 						conn.namesLck.Unlock()
 					}
 				}
-				go conn.handleSignal(msg)
+				conn.handleSignal(msg)
 			case TypeMethodCall:
 				go conn.handleCall(msg)
 			}

--- a/conn.go
+++ b/conn.go
@@ -160,7 +160,7 @@ func Dial(address string) (*Conn, error) {
 	if err != nil {
 		return nil, err
 	}
-	return newConn(tr, newDefaultHandler(), newDefaultSignalHandler())
+	return newConn(tr, NewDefaultHandler(), NewDefaultSignalHandler())
 }
 
 // DialHandler establishes a new private connection to the message bus specified by address, using the supplied handlers.
@@ -174,7 +174,7 @@ func DialHandler(address string, handler Handler, signalHandler SignalHandler) (
 
 // NewConn creates a new private *Conn from an already established connection.
 func NewConn(conn io.ReadWriteCloser) (*Conn, error) {
-	return NewConnHandler(conn, newDefaultHandler(), newDefaultSignalHandler())
+	return NewConnHandler(conn, NewDefaultHandler(), NewDefaultSignalHandler())
 }
 
 // NewConnHandler creates a new private *Conn from an already established connection, using the supplied handlers.

--- a/default_handler.go
+++ b/default_handler.go
@@ -18,7 +18,10 @@ func newIntrospectIntf(h *defaultHandler) *exportedIntf {
 	return newExportedIntf(methods, true)
 }
 
-func newDefaultHandler() *defaultHandler {
+//NewDefaultHandler returns an instance of the default
+//call handler. This is useful if you want to implement only
+//one of the two handlers but not both.
+func NewDefaultHandler() *defaultHandler {
 	h := &defaultHandler{
 		objects:     make(map[ObjectPath]*exportedObj),
 		defaultIntf: make(map[string]*exportedIntf),
@@ -214,7 +217,10 @@ func (obj *exportedIntf) isFallbackInterface() bool {
 	return obj.includeSubtree
 }
 
-func newDefaultSignalHandler() *defaultSignalHandler {
+//NewDefaultSignalHandler returns an instance of the default
+//signal handler. This is useful if you want to implement only
+//one of the two handlers but not both.
+func NewDefaultSignalHandler() *defaultSignalHandler {
 	return &defaultSignalHandler{}
 }
 

--- a/default_handler.go
+++ b/default_handler.go
@@ -230,14 +230,16 @@ type defaultSignalHandler struct {
 }
 
 func (sh *defaultSignalHandler) DeliverSignal(intf, name string, signal *Signal) {
-	sh.RLock()
-	defer sh.RUnlock()
-	if sh.closed {
-		return
-	}
-	for _, ch := range sh.signals {
-		ch <- signal
-	}
+	go func() {
+		sh.RLock()
+		defer sh.RUnlock()
+		if sh.closed {
+			return
+		}
+		for _, ch := range sh.signals {
+			ch <- signal
+		}
+	}()
 }
 
 func (sh *defaultSignalHandler) Init() error {


### PR DESCRIPTION
This moves the place where the signal handler is made asynchronous. For signals
the ordering of arrivial may be important. Making them asynchronous by defualt
does not allow for this policy decision to be made by the signal handler. In
order to preserve the current behavior, make the default handler asynchronous
instead of all handlers.