### PR TITLE
Fix/97

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -116,7 +116,6 @@ func (conn *Conn) Auth(methods []Auth) error {
 						return err
 					}
 					go conn.inWorker()
-					go conn.outWorker()
 					return nil
 				}
 			}

--- a/object.go
+++ b/object.go
@@ -86,18 +86,12 @@ func (o *Object) Go(method string, flags Flags, ch chan *Call, args ...interface
 		o.conn.callsLck.Lock()
 		o.conn.calls[msg.serial] = call
 		o.conn.callsLck.Unlock()
-		o.conn.outLck.RLock()
-		if o.conn.closed {
+		o.conn.sendMessageAndIfClosed(msg, func() {
 			call.Err = ErrClosed
 			call.Done <- call
-		} else {
-			o.conn.out <- msg
-		}
-		o.conn.outLck.RUnlock()
+		})
 		return call
 	}
-	o.conn.outLck.RLock()
-	defer o.conn.outLck.RUnlock()
 	done := make(chan *Call, 1)
 	call := &Call{
 		Err:  nil,
@@ -107,11 +101,9 @@ func (o *Object) Go(method string, flags Flags, ch chan *Call, args ...interface
 		call.Done <- call
 		close(done)
 	}()
-	if o.conn.closed {
+	o.conn.sendMessageAndIfClosed(msg, func() {
 		call.Err = ErrClosed
-		return call
-	}
-	o.conn.out <- msg
+	})
 	return call
 }
 

--- a/object.go
+++ b/object.go
@@ -83,9 +83,7 @@ func (o *Object) Go(method string, flags Flags, ch chan *Call, args ...interface
 			Args:        args,
 			Done:        ch,
 		}
-		o.conn.callsLck.Lock()
-		o.conn.calls[msg.serial] = call
-		o.conn.callsLck.Unlock()
+		o.conn.calls.track(msg.serial, call)
 		o.conn.sendMessageAndIfClosed(msg, func() {
 			call.Err = ErrClosed
 			call.Done <- call


### PR DESCRIPTION
Refactors output to be synchronous to fix #97. Refactors inWorker and conn for clarity. Avoids lock handling at every call site by encapsulating shared information into objects.