### PR TITLE
Add ANONYMOUS auth

### DIFF
--- a/_examples/tcp_conn.go
+++ b/_examples/tcp_conn.go
@@ -1,0 +1,58 @@
+package main
+
+import (
+	"fmt"
+	"net"
+	"os"
+
+	"github.com/godbus/dbus"
+)
+
+// In order to enable TCP connections add the following configuration
+// file to /etc/dbus-1/system.d or /etc/dbus-1/session.d, the location
+// depends on your OS (you may update your /etc/dbus-1/session.conf instead):
+//
+// <!DOCTYPE busconfig PUBLIC "-//freedesktop//DTD D-BUS Bus Configuration 1.0//EN"
+//  "http://www.freedesktop.org/standards/dbus/1.0/busconfig.dtd">
+// <busconfig>
+//     <listen>tcp:host=localhost,bind=*,port=12345,family=ipv4</listen>
+//     <listen>unix:tmpdir=/tmp</listen>
+//     <auth>ANONYMOUS</auth>
+//     <allow_anonymous/>
+// </busconfig>
+//
+// If you're using systemd you may also need to reconfigure dbus.socket,
+// say put this into /etc/systemd/system/dbus.socket.d/overrides.conf:
+//
+// [Socket]
+// ListenStream=/var/run/dbus/system_bus_socket
+// ListenStream=12345
+//
+// Reboot.
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintf(os.Stderr, "usage: %s DBUS_TCP_ADDRESS\n", os.Args[0])
+		os.Exit(1)
+	}
+	if err := run(os.Args[1]); err != nil {
+		fmt.Fprintf(os.Stderr, "error: %s\n", err)
+		os.Exit(2)
+	}
+	fmt.Println("ok")
+}
+
+func run(addr string) error {
+	host, port, err := net.SplitHostPort(addr)
+	if err != nil {
+		return err
+	}
+	conn, err := dbus.Dial("tcp:host=" + host + ",port=" + port)
+	if err != nil {
+		return err
+	}
+	if err = conn.Auth([]dbus.Auth{dbus.AuthAnonymous()}); err != nil {
+		return err
+	}
+	return conn.Hello()
+}

--- a/auth_anonymous.go
+++ b/auth_anonymous.go
@@ -1,0 +1,16 @@
+package dbus
+
+// AuthAnonymous returns an Auth that uses the ANONYMOUS mechanism.
+func AuthAnonymous() Auth {
+	return &authAnonymous{}
+}
+
+type authAnonymous struct{}
+
+func (a *authAnonymous) FirstData() (name, resp []byte, status AuthStatus) {
+	return []byte("ANONYMOUS"), nil, AuthOk
+}
+
+func (a *authAnonymous) HandleData(data []byte) (resp []byte, status AuthStatus) {
+	return nil, AuthError
+}

--- a/encoder_test.go
+++ b/encoder_test.go
@@ -255,7 +255,7 @@ func TestEncodeIntToNonCovertible(t *testing.T) {
 	var out bool
 	err = Store(v, &out)
 	if err == nil {
-		t.Logf("%q\n", out)
+		t.Logf("%t\n", out)
 		t.Fatal("Type mismatch should have occured")
 	}
 }


### PR DESCRIPTION
Hi there!
This adds the ANONYMOUS authentication mechanism.

https://dbus.freedesktop.org/doc/dbus-specification.html#auth-protocol

> ANONYMOUS
> The ANONYMOUS mechanism is defined in RFC 4505 "Anonymous Simple Authentication and Security Layer (SASL) Mechanism". It does not perform any authentication at all, and should not be accepted by message buses. However, it might sometimes be useful for non-message-bus uses of D-Bus.

It's mainly used for remote connections.

I haven't found a way to test it (except manually) since dbus daemon requires additional configuration, if you have an idea how, I'll be glad to hear it out.
