### PR TITLE
Support passing a context to BusOject Call and Go

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 dist: precise
 language: go
-go_import_path: github.com/godbus/dbus
+go_import_path: github.com/dannin/dbus
 sudo: true
 
 go:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,10 @@ go_import_path: github.com/godbus/dbus
 sudo: true
 
 go:
-  - 1.6.3
   - 1.7.3
+  - 1.8.7
+  - 1.9.5
+  - 1.10.1
   - tip
 
 env:

--- a/README.markdown
+++ b/README.markdown
@@ -17,7 +17,7 @@ D-Bus message bus system.
 This packages requires Go 1.1. If you installed it and set up your GOPATH, just run:
 
 ```
-go get github.com/godbus/dbus
+go get github.com/dannin/dbus
 ```
 
 If you want to use the subpackages, you can install them the same way.
@@ -25,8 +25,8 @@ If you want to use the subpackages, you can install them the same way.
 ### Usage
 
 The complete package documentation and some simple examples are available at
-[godoc.org](http://godoc.org/github.com/godbus/dbus). Also, the
-[_examples](https://github.com/godbus/dbus/tree/master/_examples) directory
+[godoc.org](http://godoc.org/github.com/dannin/dbus). Also, the
+[_examples](https://github.com/dannin/dbus/tree/master/_examples) directory
 gives a short overview over the basic usage. 
 
 #### Projects using godbus

--- a/_examples/bluetooth_introspect.go
+++ b/_examples/bluetooth_introspect.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/godbus/dbus"
+	"github.com/dannin/dbus"
 )
 
 func main() {

--- a/_examples/eavesdrop.go
+++ b/_examples/eavesdrop.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"fmt"
-	"github.com/godbus/dbus"
+	"github.com/dannin/dbus"
 	"os"
 )
 

--- a/_examples/introspect.go
+++ b/_examples/introspect.go
@@ -2,8 +2,8 @@ package main
 
 import (
 	"encoding/json"
-	"github.com/godbus/dbus"
-	"github.com/godbus/dbus/introspect"
+	"github.com/dannin/dbus"
+	"github.com/dannin/dbus/introspect"
 	"os"
 )
 

--- a/_examples/list-names.go
+++ b/_examples/list-names.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"fmt"
-	"github.com/godbus/dbus"
+	"github.com/dannin/dbus"
 	"os"
 )
 

--- a/_examples/notification.go
+++ b/_examples/notification.go
@@ -1,6 +1,6 @@
 package main
 
-import "github.com/godbus/dbus"
+import "github.com/dannin/dbus"
 
 func main() {
 	conn, err := dbus.SessionBus()

--- a/_examples/prop.go
+++ b/_examples/prop.go
@@ -2,9 +2,9 @@ package main
 
 import (
 	"fmt"
-	"github.com/godbus/dbus"
-	"github.com/godbus/dbus/introspect"
-	"github.com/godbus/dbus/prop"
+	"github.com/dannin/dbus"
+	"github.com/dannin/dbus/introspect"
+	"github.com/dannin/dbus/prop"
 	"os"
 )
 

--- a/_examples/server.go
+++ b/_examples/server.go
@@ -2,8 +2,8 @@ package main
 
 import (
 	"fmt"
-	"github.com/godbus/dbus"
-	"github.com/godbus/dbus/introspect"
+	"github.com/dannin/dbus"
+	"github.com/dannin/dbus/introspect"
 	"os"
 )
 

--- a/_examples/signal.go
+++ b/_examples/signal.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"fmt"
-	"github.com/godbus/dbus"
+	"github.com/dannin/dbus"
 	"os"
 )
 

--- a/_examples/tcp_conn.go
+++ b/_examples/tcp_conn.go
@@ -5,7 +5,7 @@ import (
 	"net"
 	"os"
 
-	"github.com/godbus/dbus"
+	"github.com/dannin/dbus"
 )
 
 // In order to enable TCP connections add the following configuration

--- a/call.go
+++ b/call.go
@@ -1,8 +1,11 @@
 package dbus
 
 import (
+	"context"
 	"errors"
 )
+
+var errSignature = errors.New("dbus: mismatched signature")
 
 // Call represents a pending or completed method call.
 type Call struct {
@@ -20,9 +23,27 @@ type Call struct {
 
 	// Holds the response once the call is done.
 	Body []interface{}
+
+	// tracks context and canceler
+	ctx         context.Context
+	ctxCanceler context.CancelFunc
 }
 
-var errSignature = errors.New("dbus: mismatched signature")
+func (c *Call) Context() context.Context {
+	if c.ctx == nil {
+		return context.Background()
+	}
+
+	return c.ctx
+}
+
+func (c *Call) ContextCancelFunc() context.CancelFunc {
+	if c.ctxCanceler == nil {
+		return func() {}
+	}
+
+	return c.ctxCanceler
+}
 
 // Store stores the body of the reply into the provided pointers. It returns
 // an error if the signatures of the body and retvalues don't match, or if

--- a/conn.go
+++ b/conn.go
@@ -1,6 +1,7 @@
 package dbus
 
 import (
+	"context"
 	"errors"
 	"io"
 	"os"
@@ -369,8 +370,21 @@ func (conn *Conn) sendMessageAndIfClosed(msg *Message, ifClosed func()) {
 // once the call is complete. Otherwise, ch is ignored and a Call structure is
 // returned of which only the Err member is valid.
 func (conn *Conn) Send(msg *Message, ch chan *Call) *Call {
-	var call *Call
+	return conn.send(context.Background(), msg, ch)
+}
 
+// SendWithContext acts like Send but takes a context
+func (conn *Conn) SendWithContext(ctx context.Context, msg *Message, ch chan *Call) *Call {
+	return conn.send(ctx, msg, ch)
+}
+
+func (conn *Conn) send(ctx context.Context, msg *Message, ch chan *Call) *Call {
+	if ctx == nil {
+		panic("nil context")
+	}
+
+	var call *Call
+	ctx, canceler := context.WithCancel(ctx)
 	msg.serial = conn.getSerial()
 	if msg.Type == TypeMethodCall && msg.Flags&FlagNoReplyExpected == 0 {
 		if ch == nil {
@@ -386,12 +400,19 @@ func (conn *Conn) Send(msg *Message, ch chan *Call) *Call {
 		call.Method = iface + "." + member
 		call.Args = msg.Body
 		call.Done = ch
+		call.ctx = ctx
+		call.ctxCanceler = canceler
 		conn.calls.track(msg.serial, call)
+		go func() {
+			<-ctx.Done()
+			conn.calls.handleSendError(msg, ErrClosed)
+		}()
 		conn.sendMessageAndIfClosed(msg, func() {
-			call.Err = ErrClosed
-			call.Done <- call
+			conn.calls.handleSendError(msg, ErrClosed)
+			canceler()
 		})
 	} else {
+		canceler()
 		call = &Call{Err: nil}
 		conn.sendMessageAndIfClosed(msg, func() {
 			call = &Call{Err: ErrClosed}
@@ -705,29 +726,24 @@ func (tracker *callTracker) track(sn uint32, call *Call) {
 func (tracker *callTracker) handleReply(msg *Message) uint32 {
 	serial := msg.Headers[FieldReplySerial].value.(uint32)
 	tracker.lck.RLock()
-	c, ok := tracker.calls[serial]
+	_, ok := tracker.calls[serial]
 	tracker.lck.RUnlock()
-	if !ok {
-		return serial
+	if ok {
+		tracker.finalizeWithBody(serial, msg.Body)
 	}
-	c.Body = msg.Body
-	c.Done <- c
-	tracker.finalize(serial)
 	return serial
 }
 
 func (tracker *callTracker) handleDBusError(msg *Message) uint32 {
 	serial := msg.Headers[FieldReplySerial].value.(uint32)
 	tracker.lck.RLock()
-	c, ok := tracker.calls[serial]
+	_, ok := tracker.calls[serial]
 	tracker.lck.RUnlock()
 	if !ok {
 		return serial
 	}
 	name, _ := msg.Headers[FieldErrorName].value.(string)
-	c.Err = Error{name, msg.Body}
-	c.Done <- c
-	tracker.finalize(serial)
+	tracker.finalizeWithError(serial, Error{name, msg.Body})
 	return serial
 }
 
@@ -736,32 +752,68 @@ func (tracker *callTracker) handleSendError(msg *Message, err error) {
 		return
 	}
 	tracker.lck.RLock()
-	c, ok := tracker.calls[msg.serial]
+	_, ok := tracker.calls[msg.serial]
 	tracker.lck.RUnlock()
-	if !ok {
-		return
+	if ok {
+		tracker.finalizeWithError(msg.serial, err)
 	}
-	c.Err = err
-	c.Done <- c
-	tracker.finalize(msg.serial)
 }
 
+// finalize was the only func that did not strobe Done
 func (tracker *callTracker) finalize(sn uint32) {
 	tracker.lck.Lock()
 	defer tracker.lck.Unlock()
-	delete(tracker.calls, sn)
+	c, ok := tracker.calls[sn]
+	if ok {
+		delete(tracker.calls, sn)
+		c.ContextCancelFunc()()
+	}
+	return
+}
+
+func (tracker *callTracker) finalizeWithBody(sn uint32, body []interface{}) {
+	tracker.lck.Lock()
+	c, ok := tracker.calls[sn]
+	if ok {
+		delete(tracker.calls, sn)
+	}
+	tracker.lck.Unlock()
+	if ok {
+		c.Body = body
+		done(c)
+	}
+	return
+}
+
+func (tracker *callTracker) finalizeWithError(sn uint32, err error) {
+	tracker.lck.Lock()
+	c, ok := tracker.calls[sn]
+	if ok {
+		delete(tracker.calls, sn)
+	}
+	tracker.lck.Unlock()
+	if ok {
+		c.Err = err
+		done(c)
+	}
+	return
 }
 
 func (tracker *callTracker) finalizeAllWithError(err error) {
-	closedCalls := make(map[uint32]*Call)
-	tracker.lck.RLock()
-	for sn, v := range tracker.calls {
-		v.Err = err
-		v.Done <- v
-		closedCalls[sn] = v
+	var closedCalls []*Call
+	tracker.lck.Lock()
+	for _, call := range tracker.calls {
+		closedCalls = append(closedCalls, call)
 	}
-	tracker.lck.RUnlock()
-	for sn := range closedCalls {
-		tracker.finalize(sn)
+	tracker.calls = map[uint32]*Call{}
+	tracker.lck.Unlock()
+	for _, call := range closedCalls {
+		call.Err = err
+		done(call)
 	}
+}
+
+func done(call *Call) {
+	call.Done <- call
+	call.ContextCancelFunc()()
 }

--- a/introspect/call.go
+++ b/introspect/call.go
@@ -2,7 +2,7 @@ package introspect
 
 import (
 	"encoding/xml"
-	"github.com/godbus/dbus"
+	"github.com/dannin/dbus"
 	"strings"
 )
 

--- a/introspect/introspectable.go
+++ b/introspect/introspectable.go
@@ -2,7 +2,7 @@ package introspect
 
 import (
 	"encoding/xml"
-	"github.com/godbus/dbus"
+	"github.com/dannin/dbus"
 	"reflect"
 	"strings"
 )

--- a/object_test.go
+++ b/object_test.go
@@ -1,0 +1,59 @@
+package dbus
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+type objectGoContextServer struct {
+	t     *testing.T
+	sleep time.Duration
+}
+
+func (o objectGoContextServer) Sleep() *Error {
+	o.t.Log("Got object call and sleeping for ", o.sleep)
+	time.Sleep(o.sleep)
+	o.t.Log("Completed sleeping for ", o.sleep)
+	return nil
+}
+
+func TestObjectGoWithContextTimeout(t *testing.T) {
+	bus, err := SessionBus()
+	if err != nil {
+		t.Fatalf("Unexpected error connecting to session bus: %s", err)
+	}
+
+	name := bus.Names()[0]
+	bus.Export(objectGoContextServer{t, time.Second}, "/org/dannin/DBus/Test", "org.dannin.DBus.Test")
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	select {
+	case call := <-bus.Object(name, "/org/dannin/DBus/Test").GoWithContext(ctx, "org.dannin.DBus.Test.Sleep", 0, nil).Done:
+		if call.Err != ctx.Err() {
+			t.Fatal("Expected ", ctx.Err(), " but got ", call.Err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Expected call to not respond in time")
+	}
+}
+
+func TestObjectGoWithContext(t *testing.T) {
+	bus, err := SessionBus()
+	if err != nil {
+		t.Fatalf("Unexpected error connecting to session bus: %s", err)
+	}
+
+	name := bus.Names()[0]
+	bus.Export(objectGoContextServer{t, time.Millisecond}, "/org/dannin/DBus/Test", "org.dannin.DBus.Test")
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	select {
+	case call := <-bus.Object(name, "/org/dannin/DBus/Test").GoWithContext(ctx, "org.dannin.DBus.Test.Sleep", 0, nil).Done:
+		if call.Err != ctx.Err() {
+			t.Fatal("Expected ", ctx.Err(), " but got ", call.Err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("Expected call to respond in 1 Millisecond")
+	}
+}

--- a/prop/prop.go
+++ b/prop/prop.go
@@ -3,8 +3,8 @@
 package prop
 
 import (
-	"github.com/godbus/dbus"
-	"github.com/godbus/dbus/introspect"
+	"github.com/dannin/dbus"
+	"github.com/dannin/dbus/introspect"
 	"sync"
 )
 

--- a/transport_generic.go
+++ b/transport_generic.go
@@ -11,7 +11,7 @@ var nativeEndian binary.ByteOrder
 
 func detectEndianness() binary.ByteOrder {
 	var x uint32 = 0x01020304
-		if *(*byte)(unsafe.Pointer(&x)) == 0x01 {
+	if *(*byte)(unsafe.Pointer(&x)) == 0x01 {
 		return binary.BigEndian
 	}
 	return binary.LittleEndian


### PR DESCRIPTION
Sometimes a method call may take too much time replying or may never reply, causing message to block indefinitely.  Support adding a context.Context which can help.