### PR TITLE
Support passing a context to BusOject Call and Go

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,10 @@ go_import_path: github.com/godbus/dbus
 sudo: true
 
 go:
-  - 1.6.3
   - 1.7.3
+  - 1.8.7
+  - 1.9.5
+  - 1.10.1
   - tip
 
 env:
@@ -38,3 +40,7 @@ addons:
     - dbus-x11
 
 before_install:
+
+script:
+  - go test -v -race ./...                   # Run all the tests with the race detector enabled
+  - go vet ./...                             # go vet is the official Go static analyzer

--- a/object_test.go
+++ b/object_test.go
@@ -1,0 +1,59 @@
+package dbus
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+type objectGoContextServer struct {
+	t     *testing.T
+	sleep time.Duration
+}
+
+func (o objectGoContextServer) Sleep() *Error {
+	o.t.Log("Got object call and sleeping for ", o.sleep)
+	time.Sleep(o.sleep)
+	o.t.Log("Completed sleeping for ", o.sleep)
+	return nil
+}
+
+func TestObjectGoWithContextTimeout(t *testing.T) {
+	bus, err := SessionBus()
+	if err != nil {
+		t.Fatalf("Unexpected error connecting to session bus: %s", err)
+	}
+
+	name := bus.Names()[0]
+	bus.Export(objectGoContextServer{t, time.Second}, "/org/dannin/DBus/Test", "org.dannin.DBus.Test")
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	select {
+	case call := <-bus.Object(name, "/org/dannin/DBus/Test").GoWithContext(ctx, "org.dannin.DBus.Test.Sleep", 0, nil).Done:
+		if call.Err != ctx.Err() {
+			t.Fatal("Expected ", ctx.Err(), " but got ", call.Err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Expected call to not respond in time")
+	}
+}
+
+func TestObjectGoWithContext(t *testing.T) {
+	bus, err := SessionBus()
+	if err != nil {
+		t.Fatalf("Unexpected error connecting to session bus: %s", err)
+	}
+
+	name := bus.Names()[0]
+	bus.Export(objectGoContextServer{t, time.Millisecond}, "/org/dannin/DBus/Test", "org.dannin.DBus.Test")
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	select {
+	case call := <-bus.Object(name, "/org/dannin/DBus/Test").GoWithContext(ctx, "org.dannin.DBus.Test.Sleep", 0, nil).Done:
+		if call.Err != ctx.Err() {
+			t.Fatal("Expected ", ctx.Err(), " but got ", call.Err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("Expected call to respond in 1 Millisecond")
+	}
+}

--- a/prop/prop.go
+++ b/prop/prop.go
@@ -43,24 +43,24 @@ var IntrospectData = introspect.Interface{
 		{
 			Name: "Get",
 			Args: []introspect.Arg{
-				{"interface", "s", "in"},
-				{"property", "s", "in"},
-				{"value", "v", "out"},
+				{Name: "interface", Type: "s", Direction: "in"},
+				{Name: "property", Type: "s", Direction: "in"},
+				{Name: "value", Type: "v", Direction: "out"},
 			},
 		},
 		{
 			Name: "GetAll",
 			Args: []introspect.Arg{
-				{"interface", "s", "in"},
-				{"props", "a{sv}", "out"},
+				{Name: "interface", Type: "s", Direction: "in"},
+				{Name: "props", Type: "a{sv}", Direction: "out"},
 			},
 		},
 		{
 			Name: "Set",
 			Args: []introspect.Arg{
-				{"interface", "s", "in"},
-				{"property", "s", "in"},
-				{"value", "v", "in"},
+				{Name: "interface", Type: "s", Direction: "in"},
+				{Name: "property", Type: "s", Direction: "in"},
+				{Name: "value", Type: "v", Direction: "in"},
 			},
 		},
 	},
@@ -68,9 +68,9 @@ var IntrospectData = introspect.Interface{
 		{
 			Name: "PropertiesChanged",
 			Args: []introspect.Arg{
-				{"interface", "s", "out"},
-				{"changed_properties", "a{sv}", "out"},
-				{"invalidates_properties", "as", "out"},
+				{Name: "interface", Type: "s", Direction: "out"},
+				{Name: "changed_properties", Type: "a{sv}", Direction: "out"},
+				{Name: "invalidates_properties", Type: "as", Direction: "out"},
 			},
 		},
 	},

--- a/server_interfaces_test.go
+++ b/server_interfaces_test.go
@@ -2,14 +2,17 @@ package dbus
 
 import (
 	"fmt"
+	"sync"
 	"testing"
 	"time"
 )
 
 type tester struct {
-	conn    *Conn
-	sigs    chan *Signal
-	subSigs map[string]map[string]struct{}
+	conn *Conn
+	sigs chan *Signal
+
+	subSigsMu sync.Mutex
+	subSigs   map[string]map[string]struct{}
 }
 
 type intro struct {
@@ -147,7 +150,9 @@ func (t terrfn) ReturnValue(position int) interface{} {
 
 //SignalHandler
 func (t *tester) DeliverSignal(iface, name string, signal *Signal) {
+	t.subSigsMu.Lock()
 	intf, ok := t.subSigs[iface]
+	t.subSigsMu.Unlock()
 	if !ok {
 		return
 	}
@@ -158,12 +163,14 @@ func (t *tester) DeliverSignal(iface, name string, signal *Signal) {
 }
 
 func (t *tester) AddSignal(iface, name string) {
+	t.subSigsMu.Lock()
 	if i, ok := t.subSigs[iface]; ok {
 		i[name] = struct{}{}
 	} else {
 		t.subSigs[iface] = make(map[string]struct{})
 		t.subSigs[iface][name] = struct{}{}
 	}
+	t.subSigsMu.Unlock()
 	t.conn.BusObject().(*Object).AddMatchSignal(
 		iface, name)
 }

--- a/transport_generic.go
+++ b/transport_generic.go
@@ -11,7 +11,7 @@ var nativeEndian binary.ByteOrder
 
 func detectEndianness() binary.ByteOrder {
 	var x uint32 = 0x01020304
-		if *(*byte)(unsafe.Pointer(&x)) == 0x01 {
+	if *(*byte)(unsafe.Pointer(&x)) == 0x01 {
 		return binary.BigEndian
 	}
 	return binary.LittleEndian


### PR DESCRIPTION
Create a child context and canceler that can be passed around with the Call.
When the Call is complete, invoke the canceler.
Because multiple places can now finalize a call, make all finalize methods non-racy.