### PR TITLE
Add TCP noncefile transport

### DIFF
--- a/transport_nonce_tcp.go
+++ b/transport_nonce_tcp.go
@@ -1,0 +1,39 @@
+//+build !windows
+
+package dbus
+
+import (
+	"errors"
+	"io/ioutil"
+	"net"
+)
+
+func init() {
+	transports["nonce-tcp"] = newNonceTcpTransport
+}
+
+func newNonceTcpTransport(keys string) (transport, error) {
+	host := getKey(keys, "host")
+	port := getKey(keys, "port")
+	noncefile := getKey(keys, "noncefile")
+	if host == "" || port == "" || noncefile == "" {
+		return nil, errors.New("dbus: unsupported address (must set host, port and noncefile)")
+	}
+	protocol, err := tcpFamily(keys)
+	if err != nil {
+		return nil, err
+	}
+	socket, err := net.Dial(protocol, net.JoinHostPort(host, port))
+	if err != nil {
+		return nil, err
+	}
+	b, err := ioutil.ReadFile(noncefile)
+	if err != nil {
+		return nil, err
+	}
+	_, err = socket.Write(b)
+	if err != nil {
+		return nil, err
+	}
+	return NewConn(socket)
+}

--- a/transport_nonce_tcp_test.go
+++ b/transport_nonce_tcp_test.go
@@ -1,0 +1,67 @@
+package dbus
+
+import (
+	"bufio"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"testing"
+)
+
+func TestTcpNonceConnection(t *testing.T) {
+	addr, process := startDaemon(t, `<!DOCTYPE busconfig PUBLIC "-//freedesktop//DTD D-BUS Bus Configuration 1.0//EN"
+ "http://www.freedesktop.org/standards/dbus/1.0/busconfig.dtd">
+<busconfig>
+	<type>session</type>
+		<listen>nonce-tcp:</listen>
+		<auth>ANONYMOUS</auth>
+		<allow_anonymous/>
+		<policy context="default">
+			<allow send_destination="*" eavesdrop="true"/>
+			<allow eavesdrop="true"/>
+			<allow own="*"/>
+		</policy>
+</busconfig>
+`)
+	defer process.Kill()
+
+	c, err := Dial(addr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err = c.Auth([]Auth{AuthAnonymous()}); err != nil {
+		t.Fatal(err)
+	}
+	if err = c.Hello(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// startDaemon starts a dbus-daemon instance with the given config
+// and returns its address string and underlying process.
+func startDaemon(t *testing.T, config string) (string, *os.Process) {
+	cfg, err := ioutil.TempFile("", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(cfg.Name())
+	if _, err = cfg.Write([]byte(config)); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := exec.Command("dbus-daemon", "--nofork", "--print-address", "--config-file", cfg.Name())
+	out, err := cmd.StdoutPipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err = cmd.Start(); err != nil {
+		t.Fatal(err)
+	}
+	r := bufio.NewReader(out)
+	l, _, err := r.ReadLine()
+	if err != nil {
+		cmd.Process.Kill()
+		t.Fatal(err)
+	}
+	return string(l), cmd.Process
+}


### PR DESCRIPTION
Hi there,

Currently the noncefile implementation is missing, it's needed for authenticated TCP connection. See more: https://dbus.freedesktop.org/doc/dbus-specification.html#transports-nonce-tcp-sockets

Not very sure about the integration test I added, the dbus package has to be installed on CI to make it pass.