### PR TITLE
Fix decoder for arrays of structs

### DIFF
--- a/decoder.go
+++ b/decoder.go
@@ -191,7 +191,14 @@ func (dec *decoder) decode(s string, depth int) interface{} {
 		length := dec.decode("u", depth).(uint32)
 		v := reflect.MakeSlice(reflect.SliceOf(typeFor(s[1:])), 0, int(length))
 		// Even for empty arrays, the correct padding must be included
-		dec.align(alignment(typeFor(s[1:])))
+		align := alignment(typeFor(s[1:]))
+		if len(s) > 1 && s[1] == '(' {
+			//Special case for arrays of structs
+			//structs decode as a slice of interface{} values
+			//but the dbus alignment does not match this
+			align = 8
+		}
+		dec.align(align)
 		spos := dec.pos
 		for dec.pos < spos+int(length) {
 			ev := dec.decode(s[1:], depth+1)

--- a/decoder_test.go
+++ b/decoder_test.go
@@ -1,0 +1,72 @@
+package dbus
+
+import (
+	"bytes"
+	"encoding/binary"
+	"testing"
+)
+
+type pixmap struct {
+	Width  int
+	Height int
+	Pixels []uint8
+}
+
+type property struct {
+	IconName    string
+	Pixmaps     []pixmap
+	Title       string
+	Description string
+}
+
+func TestDecodeArrayEmptyStruct(t *testing.T) {
+	buf := bytes.NewBuffer(nil)
+	msg := &Message{
+		Type:  0x02,
+		Flags: 0x00,
+		Headers: map[HeaderField]Variant{
+			0x06: Variant{
+				sig: Signature{
+					str: "s",
+				},
+				value: ":1.391",
+			},
+			0x05: Variant{
+				sig: Signature{
+					str: "u",
+				},
+				value: uint32(2),
+			},
+			0x08: Variant{
+				sig: Signature{
+					str: "g",
+				},
+				value: Signature{
+					str: "v",
+				},
+			},
+		},
+		Body: []interface{}{
+			Variant{
+				sig: Signature{
+					str: "(sa(iiay)ss)",
+				},
+				value: property{
+					IconName:    "iconname",
+					Pixmaps:     []pixmap{},
+					Title:       "title",
+					Description: "description",
+				},
+			},
+		},
+		serial: 0x00000003,
+	}
+	err := msg.EncodeTo(buf, binary.LittleEndian)
+	if err != nil {
+		t.Fatal(err)
+	}
+	msg, err = DecodeMessage(buf)
+	if err != nil {
+		t.Fatal(err)
+	}
+}


### PR DESCRIPTION
    Arrays of structs are a special case for the decoder. Since it needs
    to decode structs as an array of interface{} values instead of a known
    type first, but we also want to allow decoding of an array of
    interface{} values and the two have different alignment offsets we
    need to account for the difference in the array decoding.

    Fixes #85