### PR TITLE
Bumped Go version requirement to 1.7 in README

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -14,7 +14,7 @@ D-Bus message bus system.
 
 ### Installation
 
-This packages requires Go 1.1. If you installed it and set up your GOPATH, just run:
+This packages requires Go 1.7. If you installed it and set up your GOPATH, just run:
 
 ```
 go get github.com/godbus/dbus


### PR DESCRIPTION
Since godbus now uses the `context` package, the actual required version got bumped to Go 1.7.