### PR TITLE
Fix for Windows

### DIFF
--- a/conn_windows.go
+++ b/conn_windows.go
@@ -2,6 +2,7 @@
 
 package dbus
 
+import "os"
 
 const defaultSystemBusAddress = "tcp:host=127.0.0.1,port=12434"
 


### PR DESCRIPTION
This fixes following error:

```bat
> go get -u github.com/godbus/dbus
# github.com/godbus/dbus
...\conn_windows.go:9:13: undefined: os
```