### PR TITLE
Add SerialGenerator interface and connection options 

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -15,7 +15,6 @@ var (
 	systemBusLck  sync.Mutex
 	sessionBus    *Conn
 	sessionBusLck sync.Mutex
-	sessionEnvLck sync.Mutex
 )
 
 // ErrClosed is the error returned by calls on a closed connection.
@@ -82,8 +81,6 @@ func SessionBus() (conn *Conn, err error) {
 }
 
 func getSessionBusAddress() (string, error) {
-	sessionEnvLck.Lock()
-	defer sessionEnvLck.Unlock()
 	address := os.Getenv("DBUS_SESSION_BUS_ADDRESS")
 	if address != "" && address != "autolaunch:" {
 		return address, nil

--- a/conn_test.go
+++ b/conn_test.go
@@ -160,6 +160,7 @@ func (server) Double(i int64) (int64, *Error) {
 
 func BenchmarkCall(b *testing.B) {
 	b.StopTimer()
+	b.ReportAllocs()
 	var s string
 	bus, err := SessionBus()
 	if err != nil {
@@ -181,6 +182,7 @@ func BenchmarkCall(b *testing.B) {
 
 func BenchmarkCallAsync(b *testing.B) {
 	b.StopTimer()
+	b.ReportAllocs()
 	bus, err := SessionBus()
 	if err != nil {
 		b.Fatal(err)

--- a/default_handler.go
+++ b/default_handler.go
@@ -21,6 +21,8 @@ func newIntrospectIntf(h *defaultHandler) *exportedIntf {
 //NewDefaultHandler returns an instance of the default
 //call handler. This is useful if you want to implement only
 //one of the two handlers but not both.
+//
+// Deprecated: this is the default value, don't use it, it will be unexported.
 func NewDefaultHandler() *defaultHandler {
 	h := &defaultHandler{
 		objects:     make(map[ObjectPath]*exportedObj),
@@ -229,6 +231,8 @@ func (obj *exportedIntf) isFallbackInterface() bool {
 //NewDefaultSignalHandler returns an instance of the default
 //signal handler. This is useful if you want to implement only
 //one of the two handlers but not both.
+//
+// Deprecated: this is the default value, don't use it, it will be unexported.
 func NewDefaultSignalHandler() *defaultSignalHandler {
 	return &defaultSignalHandler{
 		closeChan: make(chan struct{}),

--- a/server_interfaces.go
+++ b/server_interfaces.go
@@ -87,3 +87,13 @@ type SignalHandler interface {
 type DBusError interface {
 	DBusError() (string, []interface{})
 }
+
+// SerialGenerator is responsible for serials generation.
+//
+// Different approaches for the serial generation can be used,
+// maintaining a map guarded with a mutex (the standard way) or
+// simply increment an atomic counter.
+type SerialGenerator interface {
+	GetSerial() uint32
+	RetireSerial(serial uint32)
+}


### PR DESCRIPTION
Hi there!

I added `SerialGenerator` for being able to use a hi-performant generator like the one I've implemented in thests that uses atomics.

I added `ConnOption` just like many go projects do for configuring something, without this it's not possible to add new configuration options without changing method signatures or adding new methods.

Also removed the environment mutex because it doesn't imply anything.