### PR TITLE
go mod init

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,1 @@
+module github.com/godbus/dbus


### PR DESCRIPTION
Hi there!

This initializes go1.11 modules support, so this library won't be marked as incompatible in users' `go.mod`'s.