### PR TITLE
Fix darwin compilation

### DIFF
--- a/conn_darwin.go
+++ b/conn_darwin.go
@@ -31,3 +31,7 @@ func getSystemBusPlatformAddress() string {
 	}
 	return defaultSystemBusAddress
 }
+
+func tryDiscoverDbusSessionBusAddress() string {
+	return ""
+}


### PR DESCRIPTION
tryDiscoverDbusSessionBusAddress is missing in conn_darwin.go, but is referred to from conn.go.