### PR TITLE
Correctly handle errors in `msg.EncodeTo`

### DIFF
--- a/transport_unix.go
+++ b/transport_unix.go
@@ -203,7 +203,7 @@ func (t *unixTransport) SendMessage(msg *Message) error {
 		}
 	} else {
 		if err := msg.EncodeTo(t, nativeEndian); err != nil {
-			return nil
+			return err
 		}
 	}
 	return nil


### PR DESCRIPTION
This addresses #141.