### PR TITLE
decoder: reduce unnecessary allocations

### DIFF
--- a/decoder.go
+++ b/decoder.go
@@ -189,7 +189,7 @@ func (dec *decoder) decode(s string, depth int) interface{} {
 			panic(FormatError("input exceeds container depth limit"))
 		}
 		length := dec.decode("u", depth).(uint32)
-		v := reflect.MakeSlice(reflect.SliceOf(typeFor(s[1:])), 0, int(length))
+		v := reflect.MakeSlice(reflect.SliceOf(typeFor(s[1:])), 0, 0)
 		// Even for empty arrays, the correct padding must be included
 		align := alignment(typeFor(s[1:]))
 		if len(s) > 1 && s[1] == '(' {


### PR DESCRIPTION
Hunting down a larger than expected usage of memory in node exporter (see https://github.com/prometheus/node_exporter/issues/1301) led me to this.

Original pprof `top10`:
```
(pprof) top10
Showing nodes accounting for 72.61MB, 99.47% of 73MB total
Dropped 33 nodes (cum <= 0.36MB)
Showing top 10 nodes out of 19
      flat  flat%   sum%        cum   cum%
   70.15MB 96.10% 96.10%    70.15MB 96.10%  reflect.unsafe_NewArray
    2.42MB  3.31% 99.41%    37.32MB 51.13%  github.com/prometheus/node_exporter/vendor/github.com/godbus/dbus.(*decoder).decode
    0.03MB 0.038% 99.45%    70.18MB 96.14%  reflect.MakeSlice
    0.01MB 0.018% 99.47%    37.34MB 51.15%  github.com/prometheus/node_exporter/vendor/github.com/godbus/dbus.(*unixTransport).ReadMessage
         0     0% 99.47%    35.50MB 48.64%  github.com/prometheus/node_exporter/collector.(*systemdCollector).Update
         0     0% 99.47%    35.50MB 48.64%  github.com/prometheus/node_exporter/collector.(*systemdCollector).getAllUnits
         0     0% 99.47%    35.50MB 48.64%  github.com/prometheus/node_exporter/collector.NodeCollector.Collect.func1
         0     0% 99.47%    35.50MB 48.64%  github.com/prometheus/node_exporter/collector.execute
         0     0% 99.47%    35.50MB 48.64%  github.com/prometheus/node_exporter/vendor/github.com/coreos/go-systemd/dbus.(*Conn).ListUnits
         0     0% 99.47%    35.50MB 48.64%  github.com/prometheus/node_exporter/vendor/github.com/coreos/go-systemd/dbus.(*Conn).listUnitsInternal
```

With patch pprof `top10`:
```
(pprof) top10
Showing nodes accounting for 2.58MB, 96.80% of 2.67MB total
Dropped 38 nodes (cum <= 0.01MB)
Showing top 10 nodes out of 45
      flat  flat%   sum%        cum   cum%
    1.43MB 53.50% 53.50%     1.43MB 53.50%  github.com/prometheus/node_exporter/vendor/github.com/godbus/dbus.(*decoder).decode
    0.45MB 16.83% 70.33%     0.59MB 22.09%  github.com/prometheus/node_exporter/collector.filterUnits
    0.45MB 16.68% 87.01%     0.45MB 16.68%  github.com/prometheus/node_exporter/collector.(*systemdCollector).getAllUnits
    0.08MB  3.07% 90.08%     0.08MB  3.07%  runtime.malg
    0.06MB  2.34% 92.42%     0.06MB  2.34%  regexp.(*bitState).reset
    0.04MB  1.35% 93.77%     0.04MB  1.35%  github.com/prometheus/node_exporter/vendor/github.com/sirupsen/logrus.(*Entry).WithFields
    0.03MB  1.19% 94.96%     0.04MB  1.49%  github.com/prometheus/node_exporter/vendor/github.com/prometheus/client_golang/prometheus.(*Registry).Gather
    0.02MB  0.75% 95.71%     0.06MB  2.10%  github.com/prometheus/node_exporter/vendor/github.com/prometheus/common/log.logger.sourced
    0.02MB  0.59% 96.30%     0.02MB  0.59%  strings.(*Replacer).build
    0.01MB   0.5% 96.80%     1.44MB 54.00%  github.com/prometheus/node_exporter/vendor/github.com/godbus/dbus.(*unixTransport).ReadMessage
```

Original pprof `list decode`:
```
         .          .    191:           length := dec.decode("u", depth).(uint32)
         .    34.91MB    192:           v := reflect.MakeSlice(reflect.SliceOf(typeFor(s[1:])), 0, int(length))
         .          .    193:           // Even for empty arrays, the correct padding must be included
         .          .    194:           align := alignment(typeFor(s[1:]))
         .          .    195:           if len(s) > 1 && s[1] == '(' {
         .          .    196:                   //Special case for arrays of structs
         .          .    197:                   //structs decode as a slice of interface{} values
         .          .    198:                   //but the dbus alignment does not match this
         .          .    199:                   align = 8
         .          .    200:           }
         .          .    201:           dec.align(align)
         .          .    202:           spos := dec.pos
         .          .    203:           for dec.pos < spos+int(length) {
         .     2.41MB    204:                   ev := dec.decode(s[1:], depth+1)
         .          .    205:                   v = reflect.Append(v, reflect.ValueOf(ev))
         .          .    206:           }
         .          .    207:           return v.Interface()
```

With patch pprof `list decode`:
```
         .          .    191:           length := dec.decode("u", depth).(uint32)
         .          .    192:           v := reflect.MakeSlice(reflect.SliceOf(typeFor(s[1:])), 0, 0)
         .          .    193:           // Even for empty arrays, the correct padding must be included
         .          .    194:           align := alignment(typeFor(s[1:]))
         .          .    195:           if len(s) > 1 && s[1] == '(' {
         .          .    196:                   //Special case for arrays of structs
         .          .    197:                   //structs decode as a slice of interface{} values
         .          .    198:                   //but the dbus alignment does not match this
         .          .    199:                   align = 8
         .          .    200:           }
         .          .    201:           dec.align(align)
         .          .    202:           spos := dec.pos
         .          .    203:           for dec.pos < spos+int(length) {
         .     1.43MB    204:                   ev := dec.decode(s[1:], depth+1)
         .          .    205:                   v = reflect.Append(v, reflect.ValueOf(ev))
         .          .    206:           }
         .          .    207:           return v.Interface()
```

From some very unscientific printf debugging, it looks like `int(length)` tends to be 45, and we only ever end up having 4 values in the slice, so the over allocation of the slice is leading to the increased memory usage.

Thoughts?