### PR TITLE
Update the server example

### DIFF
--- a/_examples/server.go
+++ b/_examples/server.go
@@ -27,6 +27,12 @@ func main() {
 	if err != nil {
 		panic(err)
 	}
+
+	f := foo("Bar!")
+	conn.Export(f, "/com/github/guelfey/Demo", "com.github.guelfey.Demo")
+	conn.Export(introspect.Introspectable(intro), "/com/github/guelfey/Demo",
+		"org.freedesktop.DBus.Introspectable")
+
 	reply, err := conn.RequestName("com.github.guelfey.Demo",
 		dbus.NameFlagDoNotQueue)
 	if err != nil {
@@ -36,10 +42,6 @@ func main() {
 		fmt.Fprintln(os.Stderr, "name already taken")
 		os.Exit(1)
 	}
-	f := foo("Bar!")
-	conn.Export(f, "/com/github/guelfey/Demo", "com.github.guelfey.Demo")
-	conn.Export(introspect.Introspectable(intro), "/com/github/guelfey/Demo",
-		"org.freedesktop.DBus.Introspectable")
 	fmt.Println("Listening on com.github.guelfey.Demo / /com/github/guelfey/Demo ...")
 	select {}
 }


### PR DESCRIPTION
The server example would throwaway the first message received on the
message bus if the server.go file were to be dbus activated.

By changing the order of the code it would receive and execute the
correct method provided by the interface instead of throwing it away
when noting mapped to it.

Signed-off-by: mattemagikern <mansgariusson@gmail.com>