### PR TITLE
Ensure no signals will be sent on a channel after RemoveSignal is called

### DIFF
--- a/conn_test.go
+++ b/conn_test.go
@@ -172,6 +172,32 @@ func TestCloseBeforeSignal(t *testing.T) {
 	}
 }
 
+func TestCloseChannelAfterRemoveSignal(t *testing.T) {
+	bus, err := NewConn(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Add an unbuffered signal channel
+	ch := make(chan *Signal)
+	bus.Signal(ch)
+
+	// Send a signal
+	msg := &Message{
+		Type: TypeSignal,
+		Headers: map[HeaderField]Variant{
+			FieldInterface: MakeVariant("foo.bar"),
+			FieldMember:    MakeVariant("bar"),
+			FieldPath:      MakeVariant(ObjectPath("/baz")),
+		},
+	}
+	bus.handleSignal(msg)
+
+	// Remove and close the signal channel
+	bus.RemoveSignal(ch)
+	close(ch)
+}
+
 func TestAddAndRemoveMatchSignal(t *testing.T) {
 	conn, err := SessionBusPrivate()
 	if err != nil {

--- a/conn_test.go
+++ b/conn_test.go
@@ -103,9 +103,9 @@ func TestRemoveSignal(t *testing.T) {
 		t.Errorf("remove signal: signals length not equal: got '%d', want '3'", len(signals))
 	}
 	signals = bus.signalHandler.(*defaultSignalHandler).signals
-	for _, bch := range signals {
-		if bch != ch2 {
-			t.Errorf("remove signal: removed signal present: got '%v', want '%v'", bch, ch2)
+	for _, scd := range signals {
+		if scd.ch != ch2 {
+			t.Errorf("remove signal: removed signal present: got '%v', want '%v'", scd.ch, ch2)
 		}
 	}
 }


### PR DESCRIPTION
This fixes #158.

At present, if a signal channel's buffer is full (or it is unbuffered with no reader), a goroutine will be spun up waiting for the channel to become ready.  These goroutines will persist even after a `RemoveSignal` call, and will panic if the underlying channel is closed.

This PR pushes the wait group and closeChan down to being per-channel rather than global to the defaultSignalHandler instance.  This way we can guarantee that any associated goroutines will exit when we call RemoveSignal for a particular channel, making it safe to close.