### PR TITLE
Fix DBUS_SYSTEM_BUS_ADDRESS handling

### DIFF
--- a/conn_unix.go
+++ b/conn_unix.go
@@ -12,7 +12,7 @@ const defaultSystemBusAddress = "unix:path=/var/run/dbus/system_bus_socket"
 func getSystemBusPlatformAddress() string {
 	address := os.Getenv("DBUS_SYSTEM_BUS_ADDRESS")
 	if address != "" {
-		return fmt.Sprintf("unix:path=%s", address)
+		return address
 	}
 	return defaultSystemBusAddress
 }

--- a/conn_unix.go
+++ b/conn_unix.go
@@ -4,7 +4,6 @@ package dbus
 
 import (
 	"os"
-	"fmt"
 )
 
 const defaultSystemBusAddress = "unix:path=/var/run/dbus/system_bus_socket"


### PR DESCRIPTION
The dbus specification says that the environment variable must already contain the transport prefix: https://dbus.freedesktop.org/doc/dbus-specification.html#addresses

The old code would prevent the following use cases:
- set DBUS_SYSTEM_BUS_ADDRESS to "unix:path=/var/run/dbus/special_system_bus_socket" which is how it has to be set for e.g. glib dbus to be able to connect. This would lead to getSystemBusPlatformAddress returning a broken "unix:path=unix:path=/var/run/dbus/special_system_bus_socket".
- set DBUS_SYSTEM_BUS_ADDRESS to "unixexec:path=…", "tcp:host=…" or any other transport.

With this change we fix the behavior by using the environment variable as is instead of always prepending "unix:path=".