### PR TITLE
tests: explicitly disable AppArmor support in nonce-tcp test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-dist: precise
+dist: xenial
 language: go
 go_import_path: github.com/godbus/dbus
 sudo: true

--- a/transport_nonce_tcp_test.go
+++ b/transport_nonce_tcp_test.go
@@ -16,6 +16,7 @@ func TestTcpNonceConnection(t *testing.T) {
 		<listen>nonce-tcp:</listen>
 		<auth>ANONYMOUS</auth>
 		<allow_anonymous/>
+                <apparmor mode="disabled"/>
 		<policy context="default">
 			<allow send_destination="*" eavesdrop="true"/>
 			<allow eavesdrop="true"/>
@@ -50,6 +51,7 @@ func startDaemon(t *testing.T, config string) (string, *os.Process) {
 	}
 
 	cmd := exec.Command("dbus-daemon", "--nofork", "--print-address", "--config-file", cfg.Name())
+	cmd.Stderr = os.Stderr
 	out, err := cmd.StdoutPipe()
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
When running the test suite on my Ubuntu 19.10 system, the nonce-tcp tests failed:

```
=== RUN   TestTcpNonceConnection
--- FAIL: TestTcpNonceConnection (0.03s)
    transport_nonce_tcp_test.go:34: read tcp 127.0.0.1:48342->127.0.0.1:39743: read: connection reset by peer
```

After updating the test to stop hiding stderr from the dbus-daemon subprocess, it turned up the following error:

```
dbus-daemon[9921]: [session uid=1000 pid=9921] Unable to set up new connection: Failed to get AppArmor confinement information of socket peer: Protocol not available
```

So it looks like dbus-daemon is trying to retrieve peer credentials for the socket, which fails because it is a TCP socket.  Explicitly disabling AppArmor for this test bus seems reasonable, since it couldn't possibly work and it should be a no-op if dbus-daemon was built without AppArmor support.

I've left in the change to display stderr of dbus-daemon too.  The daemon is quiet when the test passes, and any output will be useful in debugging the test.