### PR TITLE
travis: fix cross build/run of tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,28 +8,10 @@ go:
   - 1.13.x
   - tip
 
-env:
-  global:
-  matrix:
-   - TARGET=amd64
-   - TARGET=arm64
-   - TARGET=arm
-   - TARGET=386
-   - TARGET=ppc64le
-
 matrix:
   fast_finish: true
   allow_failures:
     - go: tip
-  exclude:
-  - go: tip
-    env: TARGET=arm
-  - go: tip
-    env: TARGET=arm64
-  - go: tip
-    env: TARGET=386
-  - go: tip
-    env: TARGET=ppc64le
 
 addons:
   apt:
@@ -43,3 +25,26 @@ before_install:
 script:
   - go test -v -race -mod=readonly ./...     # Run all the tests with the race detector enabled
   - go vet ./...                             # go vet is the official Go static analyzer
+
+jobs:
+  include:
+    # The build matrix doesn't cover build stages, so manually expand
+    # the jobs with anchors
+    - &multiarch
+      stage: "Multiarch Test"
+      go: 1.11.x
+      env: TARGETS="386 arm arm64 ppc64le"
+      before_install:
+        - docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+      script:
+        - |
+          set -e
+          for target in $TARGETS; do
+            printf "\e[1mRunning test suite under ${target}.\e[0m\n"
+            GOARCH="$target" go test -v ./...
+            printf "\n\n"
+          done
+    - <<: *multiarch
+      go: 1.12.x
+    - <<: *multiarch
+      go: 1.13.x


### PR DESCRIPTION
This is an attempt to fix #162.  I've got it working as far as actually building and executing the tests on the target architectures using `qemu-user` to run non-native binaries via binfmt_misc.

The results are a bit hit and miss: the arm64 and ppc64le builds fail consistently, and the ARM version about half and half.  I suspect that's more down to problems with the CPU emulation though.

I also turned off the race detector for the !amd64 test runs, since it isn't supported there.