### PR TITLE
Add example for BecomeMonitor

### DIFF
--- a/_examples/monitor.go
+++ b/_examples/monitor.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/godbus/dbus/v5"
+)
+
+func main() {
+	conn, err := dbus.SessionBus()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "Failed to connect to session bus:", err)
+		os.Exit(1)
+	}
+
+	var rules = []string{
+		"type='signal',member='Notify',path='/org/freedesktop/Notifications',interface='org.freedesktop.Notifications'",
+		"type='method_call',member='Notify',path='/org/freedesktop/Notifications',interface='org.freedesktop.Notifications'",
+		"type='method_return',member='Notify',path='/org/freedesktop/Notifications',interface='org.freedesktop.Notifications'",
+		"type='error',member='Notify',path='/org/freedesktop/Notifications',interface='org.freedesktop.Notifications'",
+	}
+	var flag uint = 0
+
+	call := conn.BusObject().Call("org.freedesktop.DBus.Monitoring.BecomeMonitor", 0, rules, flag)
+	if call.Err != nil {
+		fmt.Fprintln(os.Stderr, "Failed to become monitor:", call.Err)
+		os.Exit(1)
+	}
+
+	c := make(chan *dbus.Message, 10)
+	conn.Eavesdrop(c)
+	fmt.Println("Monitoring notifications")
+	for v := range c {
+		fmt.Println(v)
+	}
+}


### PR DESCRIPTION
`eavesdrop='true'` is deprecated on dbus 1.12.0 (2017-10-30) in favor of `BecomeMonitor` method. This is a example of how to use `BecomeMonitor` with this library.