### PR TITLE
Allow race-free implementation of the State Caching Proxy Pattern.

### DIFF
--- a/call.go
+++ b/call.go
@@ -24,6 +24,15 @@ type Call struct {
 	// Holds the response once the call is done.
 	Body []interface{}
 
+	// ResponseSequence stores the sequence number of the DBus message containing
+	// the call response (or error). This can be compared to the sequence number
+	// of other call responses and signals on this connection to determine their
+	// relative ordering on the underlying DBus connection.
+	// For errors, ResponseSequence is populated only if the error came from a
+	// DBusMessage that was received or if there was an error receiving. In case of
+	// failure to make the call, ResponseSequence will be NoSequence.
+	ResponseSequence Sequence
+
 	// tracks context and canceler
 	ctx         context.Context
 	ctxCanceler context.CancelFunc

--- a/conn.go
+++ b/conn.go
@@ -363,6 +363,7 @@ func (conn *Conn) Hello() error {
 // inWorker runs in an own goroutine, reading incoming messages from the
 // transport and dispatching them appropiately.
 func (conn *Conn) inWorker() {
+	sequenceGen := newSequenceGenerator()
 	for {
 		msg, err := conn.ReadMessage()
 		if err != nil {
@@ -371,7 +372,7 @@ func (conn *Conn) inWorker() {
 				// anything but to shut down all stuff and returns errors to all
 				// pending replies.
 				conn.Close()
-				conn.calls.finalizeAllWithError(err)
+				conn.calls.finalizeAllWithError(sequenceGen, err)
 				return
 			}
 			// invalid messages are ignored
@@ -400,13 +401,14 @@ func (conn *Conn) inWorker() {
 		if conn.inInt != nil {
 			conn.inInt(msg)
 		}
+		sequence := sequenceGen.next()
 		switch msg.Type {
 		case TypeError:
-			conn.serialGen.RetireSerial(conn.calls.handleDBusError(msg))
+			conn.serialGen.RetireSerial(conn.calls.handleDBusError(sequence, msg))
 		case TypeMethodReply:
-			conn.serialGen.RetireSerial(conn.calls.handleReply(msg))
+			conn.serialGen.RetireSerial(conn.calls.handleReply(sequence, msg))
 		case TypeSignal:
-			conn.handleSignal(msg)
+			conn.handleSignal(sequence, msg)
 		case TypeMethodCall:
 			go conn.handleCall(msg)
 		}
@@ -414,7 +416,7 @@ func (conn *Conn) inWorker() {
 	}
 }
 
-func (conn *Conn) handleSignal(msg *Message) {
+func (conn *Conn) handleSignal(sequence Sequence, msg *Message) {
 	iface := msg.Headers[FieldInterface].value.(string)
 	member := msg.Headers[FieldMember].value.(string)
 	// as per http://dbus.freedesktop.org/doc/dbus-specification.html ,
@@ -440,10 +442,11 @@ func (conn *Conn) handleSignal(msg *Message) {
 		}
 	}
 	signal := &Signal{
-		Sender: sender,
-		Path:   msg.Headers[FieldPath].value.(ObjectPath),
-		Name:   iface + "." + member,
-		Body:   msg.Body,
+		Sender:   sender,
+		Path:     msg.Headers[FieldPath].value.(ObjectPath),
+		Name:     iface + "." + member,
+		Body:     msg.Body,
+		Sequence: sequence,
 	}
 	conn.signalHandler.DeliverSignal(iface, member, signal)
 }
@@ -658,10 +661,11 @@ func (e Error) Error() string {
 // Signal represents a D-Bus message of type Signal. The name member is given in
 // "interface.member" notation, e.g. org.freedesktop.D-Bus.NameLost.
 type Signal struct {
-	Sender string
-	Path   ObjectPath
-	Name   string
-	Body   []interface{}
+	Sender   string
+	Path     ObjectPath
+	Name     string
+	Body     []interface{}
+	Sequence Sequence
 }
 
 // transport is a D-Bus transport.
@@ -844,25 +848,25 @@ func (tracker *callTracker) track(sn uint32, call *Call) {
 	tracker.lck.Unlock()
 }
 
-func (tracker *callTracker) handleReply(msg *Message) uint32 {
+func (tracker *callTracker) handleReply(sequence Sequence, msg *Message) uint32 {
 	serial := msg.Headers[FieldReplySerial].value.(uint32)
 	tracker.lck.RLock()
 	_, ok := tracker.calls[serial]
 	tracker.lck.RUnlock()
 	if ok {
-		tracker.finalizeWithBody(serial, msg.Body)
+		tracker.finalizeWithBody(serial, sequence, msg.Body)
 	}
 	return serial
 }
 
-func (tracker *callTracker) handleDBusError(msg *Message) uint32 {
+func (tracker *callTracker) handleDBusError(sequence Sequence, msg *Message) uint32 {
 	serial := msg.Headers[FieldReplySerial].value.(uint32)
 	tracker.lck.RLock()
 	_, ok := tracker.calls[serial]
 	tracker.lck.RUnlock()
 	if ok {
 		name, _ := msg.Headers[FieldErrorName].value.(string)
-		tracker.finalizeWithError(serial, Error{name, msg.Body})
+		tracker.finalizeWithError(serial, sequence, Error{name, msg.Body})
 	}
 	return serial
 }
@@ -875,7 +879,7 @@ func (tracker *callTracker) handleSendError(msg *Message, err error) {
 	_, ok := tracker.calls[msg.serial]
 	tracker.lck.RUnlock()
 	if ok {
-		tracker.finalizeWithError(msg.serial, err)
+		tracker.finalizeWithError(msg.serial, NoSequence, err)
 	}
 }
 
@@ -890,7 +894,7 @@ func (tracker *callTracker) finalize(sn uint32) {
 	}
 }
 
-func (tracker *callTracker) finalizeWithBody(sn uint32, body []interface{}) {
+func (tracker *callTracker) finalizeWithBody(sn uint32, sequence Sequence, body []interface{}) {
 	tracker.lck.Lock()
 	c, ok := tracker.calls[sn]
 	if ok {
@@ -899,11 +903,12 @@ func (tracker *callTracker) finalizeWithBody(sn uint32, body []interface{}) {
 	tracker.lck.Unlock()
 	if ok {
 		c.Body = body
+		c.ResponseSequence = sequence
 		c.done()
 	}
 }
 
-func (tracker *callTracker) finalizeWithError(sn uint32, err error) {
+func (tracker *callTracker) finalizeWithError(sn uint32, sequence Sequence, err error) {
 	tracker.lck.Lock()
 	c, ok := tracker.calls[sn]
 	if ok {
@@ -912,11 +917,12 @@ func (tracker *callTracker) finalizeWithError(sn uint32, err error) {
 	tracker.lck.Unlock()
 	if ok {
 		c.Err = err
+		c.ResponseSequence = sequence
 		c.done()
 	}
 }
 
-func (tracker *callTracker) finalizeAllWithError(err error) {
+func (tracker *callTracker) finalizeAllWithError(sequenceGen *sequenceGenerator, err error) {
 	tracker.lck.Lock()
 	closedCalls := make([]*Call, 0, len(tracker.calls))
 	for sn := range tracker.calls {
@@ -926,6 +932,7 @@ func (tracker *callTracker) finalizeAllWithError(err error) {
 	tracker.lck.Unlock()
 	for _, call := range closedCalls {
 		call.Err = err
+		call.ResponseSequence = sequenceGen.next()
 		call.done()
 	}
 }

--- a/conn_test.go
+++ b/conn_test.go
@@ -415,6 +415,7 @@ process:
 				return err
 			}
 		case <-ctx.Done():
+			t.Logf("Context cancelled, server emitted %v signals", state)
 			return nil
 		}
 	}

--- a/conn_test.go
+++ b/conn_test.go
@@ -541,7 +541,7 @@ loop:
 		}
 	}
 
-	t.Errorf("%v ticker emitted %v ticks/sec", d, float64(count)/4.0)
+	t.Logf("%v ticker emitted %v ticks/sec", d, float64(count)/4.0)
 }
 
 type server struct{}

--- a/conn_test.go
+++ b/conn_test.go
@@ -513,12 +513,22 @@ func TestServerClientThroughput(t *testing.T) {
 }
 
 func TestTickerPerformance(t *testing.T) {
+	testTicker(t, time.Microsecond*100)
+	testTicker(t, time.Microsecond*200)
+	testTicker(t, time.Microsecond*500)
+	testTicker(t, time.Millisecond)
+	testTicker(t, time.Millisecond*10)
+	testTicker(t, time.Millisecond*100)
+	testTicker(t, time.Millisecond*1000)
+}
+
+func testTicker(t *testing.T, d time.Duration) {
 	count := 0
 
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second*1)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*4)
 	defer cancel()
 
-	ticker := time.NewTicker(time.Microsecond * 100)
+	ticker := time.NewTicker(d)
 	defer ticker.Stop()
 
 loop:
@@ -531,7 +541,7 @@ loop:
 		}
 	}
 
-	t.Logf("100-microsecond ticker emitted %v ticks/sec", count)
+	t.Errorf("%v ticker emitted %v ticks/sec", d, float64(count)/4.0)
 }
 
 type server struct{}

--- a/conn_test.go
+++ b/conn_test.go
@@ -462,16 +462,16 @@ func serverBenchmarkProcess(ctx context.Context, srv *Conn) (int64, error) {
 	}
 }
 
-func benchmarkServerClientThroughput(b *testing.B, handler SignalHandler) {
+func TestServerClientThroughput(t *testing.T) {
 	srv, err := ConnectSessionBus()
 	defer srv.Close()
 	if err != nil {
-		b.Fatal(err)
+		t.Fatal(err)
 	}
 
 	conn, err := ConnectSessionBus(WithSignalHandler(NewSequentialSignalHandler()))
 	if err != nil {
-		b.Fatal(err)
+		t.Fatal(err)
 	}
 	defer conn.Close()
 
@@ -487,7 +487,7 @@ func benchmarkServerClientThroughput(b *testing.B, handler SignalHandler) {
 		var err error
 		serverThroughput, err = serverBenchmarkProcess(ctx, srv)
 		if err != nil {
-			b.Errorf("error in server process: %v", err)
+			t.Errorf("error in server process: %v", err)
 			// Cancel the client process.
 			cancel()
 		}
@@ -497,15 +497,15 @@ func benchmarkServerClientThroughput(b *testing.B, handler SignalHandler) {
 		var err error
 		clientThroughput, err = clientBenchmarkProcess(ctx, conn)
 		if err != nil {
-			b.Errorf("error in client process: %v", err)
+			t.Errorf("error in client process: %v", err)
 		}
 
 		// Cancel the server process.
 		cancel()
 	}()
 	wg.Wait()
-	b.ReportMetric(float64(serverThroughput), "signals_sent/sec")
-	b.ReportMetric(float64(clientThroughput), "signals_received/sec")
+	t.Log(float64(serverThroughput), "signals_sent/sec")
+	t.Log(float64(clientThroughput), "signals_received/sec")
 }
 
 type server struct{}

--- a/conn_test.go
+++ b/conn_test.go
@@ -392,7 +392,7 @@ process:
 				break process
 			}
 			if msg.IsValid() != nil {
-				t.Log("Got invalid message, discarding.")
+				t.Log("Got invalid message, discarding")
 				continue process
 			}
 			name := msg.Headers[FieldMember].value.(string)
@@ -410,7 +410,7 @@ process:
 				reply.Headers[FieldSignature] = MakeVariant(SignatureOf(reply.Body...))
 				srv.sendMessageAndIfClosed(reply, nil)
 			} else {
-				t.Log("Got unsolicited message.")
+				t.Log("Got unsolicited message")
 			}
 		case <-ticker.C:
 			state++
@@ -531,7 +531,7 @@ loop:
 		}
 	}
 
-	t.Errorf("100-microsecond ticker emitted %v ticks/sec", count)
+	t.Logf("100-microsecond ticker emitted %v ticks/sec", count)
 }
 
 type server struct{}

--- a/conn_test.go
+++ b/conn_test.go
@@ -429,7 +429,7 @@ func clientBenchmarkProcess(ctx context.Context, conn *Conn) (int64, error) {
 	); err != nil {
 		return 0, err
 	}
-	channel := make(chan *Signal, 1000)
+	channel := make(chan *Signal)
 	conn.Signal(channel)
 
 	observedSignals := int64(0)

--- a/sequence.go
+++ b/sequence.go
@@ -1,0 +1,24 @@
+package dbus
+
+// Sequence represents the value of a monotonically increasing counter.
+type Sequence uint64
+
+const (
+	// NoSequence indicates the absence of a sequence value.
+	NoSequence Sequence = 0
+)
+
+// sequenceGenerator represents a monotonically increasing counter.
+type sequenceGenerator struct {
+	nextSequence Sequence
+}
+
+func (generator *sequenceGenerator) next() Sequence {
+	result := generator.nextSequence
+	generator.nextSequence++
+	return result
+}
+
+func newSequenceGenerator() *sequenceGenerator {
+	return &sequenceGenerator{nextSequence: 1}
+}

--- a/sequence_test.go
+++ b/sequence_test.go
@@ -1,0 +1,16 @@
+package dbus
+
+import (
+	"testing"
+)
+
+func TestSequential(t *testing.T) {
+	gen := newSequenceGenerator()
+
+	for i := 1; i < 10; i++ {
+		sequence := gen.next()
+		if sequence != Sequence(i) {
+			t.Errorf("Got %v expected %v", sequence, i)
+		}
+	}
+}

--- a/sequential_handler.go
+++ b/sequential_handler.go
@@ -95,6 +95,8 @@ func (scd *sequentialSignalChannelData) deliver(signal *Signal) {
 }
 
 func (scd *sequentialSignalChannelData) deferredDeliver() {
+	defer scd.wg.Done()
+
 	// Ensure only one goroutine is in this section at once, to
 	// make sure signals are sent over ch in the order they
 	// are in the queue.
@@ -110,7 +112,6 @@ func (scd *sequentialSignalChannelData) deferredDeliver() {
 	case scd.ch <- elem.Value.(*Signal):
 	case <-scd.done:
 	}
-	scd.wg.Done()
 }
 
 func (scd *sequentialSignalChannelData) close() {

--- a/sequential_handler.go
+++ b/sequential_handler.go
@@ -1,0 +1,119 @@
+package dbus
+
+import (
+	"container/list"
+	"sync"
+)
+
+// NewSequentialSignalHandler returns an instance of a new
+// signal handler that guarantees sequential processing of signals. It is a
+// guarantee of this signal handler that signals will be written to
+// channels in the order they are received on the DBus connection.
+func NewSequentialSignalHandler() SignalHandler {
+	return &sequentialSignalHandler{}
+}
+
+type sequentialSignalHandler struct {
+	mu      sync.RWMutex
+	closed  bool
+	signals []*sequentialSignalChannelData
+}
+
+func (sh *sequentialSignalHandler) DeliverSignal(intf, name string, signal *Signal) {
+	sh.mu.RLock()
+	defer sh.mu.RUnlock()
+	if sh.closed {
+		return
+	}
+	for _, scd := range sh.signals {
+		scd.deliver(signal)
+	}
+}
+
+func (sh *sequentialSignalHandler) Terminate() {
+	sh.mu.Lock()
+	defer sh.mu.Unlock()
+	if sh.closed {
+		return
+	}
+
+	for _, scd := range sh.signals {
+		scd.close()
+		close(scd.ch)
+	}
+	sh.closed = true
+	sh.signals = nil
+}
+
+func (sh *sequentialSignalHandler) AddSignal(ch chan<- *Signal) {
+	sh.mu.Lock()
+	defer sh.mu.Unlock()
+	if sh.closed {
+		return
+	}
+	sh.signals = append(sh.signals, &sequentialSignalChannelData{
+		queue: list.New(),
+		ch:    ch,
+		done:  make(chan struct{}),
+	})
+}
+
+func (sh *sequentialSignalHandler) RemoveSignal(ch chan<- *Signal) {
+	sh.mu.Lock()
+	defer sh.mu.Unlock()
+	if sh.closed {
+		return
+	}
+	for i := len(sh.signals) - 1; i >= 0; i-- {
+		if ch == sh.signals[i].ch {
+			sh.signals[i].close()
+			copy(sh.signals[i:], sh.signals[i+1:])
+			sh.signals[len(sh.signals)-1] = nil
+			sh.signals = sh.signals[:len(sh.signals)-1]
+		}
+	}
+}
+
+type sequentialSignalChannelData struct {
+	stateLock sync.Mutex
+	writeLock sync.Mutex
+	queue     *list.List
+	wg        sync.WaitGroup
+	ch        chan<- *Signal
+	done      chan struct{}
+}
+
+func (scd *sequentialSignalChannelData) deliver(signal *Signal) {
+	// Avoid blocking the main DBus message processing routine;
+	// queue signal to be dispatched later.
+	scd.stateLock.Lock()
+	scd.queue.PushBack(signal)
+	scd.stateLock.Unlock()
+
+	scd.wg.Add(1)
+	go scd.deferredDeliver()
+}
+
+func (scd *sequentialSignalChannelData) deferredDeliver() {
+	// Ensure only one goroutine is in this section at once, to
+	// make sure signals are sent over ch in the order they
+	// are in the queue.
+	scd.writeLock.Lock()
+	defer scd.writeLock.Unlock()
+
+	scd.stateLock.Lock()
+	elem := scd.queue.Front()
+	scd.queue.Remove(elem)
+	scd.stateLock.Unlock()
+
+	select {
+	case scd.ch <- elem.Value.(*Signal):
+	case <-scd.done:
+	}
+	scd.wg.Done()
+}
+
+func (scd *sequentialSignalChannelData) close() {
+	close(scd.done)
+	scd.wg.Wait() // wait until all spawned goroutines return
+}

--- a/sequential_handler_test.go
+++ b/sequential_handler_test.go
@@ -1,0 +1,258 @@
+package dbus
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+)
+
+// Verifies that no signals are dropped, even if there is not enough space
+// in the destination channel.
+func TestSequentialHandlerNoDrop(t *testing.T) {
+	t.Parallel()
+
+	handler := NewSequentialSignalHandler()
+
+	channel := make(chan *Signal, 2)
+	handler.(SignalRegistrar).AddSignal(channel)
+
+	writeSignals(handler, 1000)
+
+	if err := readSignals(t, channel, 1000); err != nil {
+		t.Error(err)
+	}
+}
+
+// Verifies that signals are written to the destination channel in the
+// order they are received, in a typical concurrent reader/writer scenario.
+func TestSequentialHandlerSequential(t *testing.T) {
+	t.Parallel()
+
+	handler := NewSequentialSignalHandler()
+
+	channel := make(chan *Signal, 10)
+	handler.(SignalRegistrar).AddSignal(channel)
+
+	done := make(chan struct{})
+
+	// Concurrently read and write signals
+	go func() {
+		if err := readSignals(t, channel, 1000); err != nil {
+			t.Error(err)
+		}
+		close(done)
+	}()
+	writeSignals(handler, 1000)
+	<-done
+}
+
+// Test that in the case of multiple destination channels, one channel
+// being blocked does not prevent the other channel receiving messages.
+func TestSequentialHandlerMultipleChannel(t *testing.T) {
+	t.Parallel()
+
+	handler := NewSequentialSignalHandler()
+
+	channelOne := make(chan *Signal)
+	handler.(SignalRegistrar).AddSignal(channelOne)
+
+	channelTwo := make(chan *Signal, 10)
+	handler.(SignalRegistrar).AddSignal(channelTwo)
+
+	writeSignals(handler, 1000)
+
+	if err := readSignals(t, channelTwo, 1000); err != nil {
+		t.Error(err)
+	}
+}
+
+// Test that removing one channel results in no more messages being
+// written to that channel.
+func TestSequentialHandler_RemoveOneChannelOfOne(t *testing.T) {
+	t.Parallel()
+	handler := NewSequentialSignalHandler()
+
+	channelOne := make(chan *Signal)
+	handler.(SignalRegistrar).AddSignal(channelOne)
+
+	writeSignals(handler, 1000)
+
+	handler.(SignalRegistrar).RemoveSignal(channelOne)
+
+	count, closed := countSignals(channelOne)
+	if count > 1 {
+		t.Error("handler continued writing to channel after removal")
+	}
+	if closed {
+		t.Error("handler closed channel on .RemoveChannel()")
+	}
+}
+
+// Test that removing one channel results in no more messages being
+// written to that channel, and the other channels are unaffected.
+func TestSequentialHandler_RemoveOneChannelOfMany(t *testing.T) {
+	t.Parallel()
+	handler := NewSequentialSignalHandler()
+
+	channelOne := make(chan *Signal)
+	handler.(SignalRegistrar).AddSignal(channelOne)
+
+	channelTwo := make(chan *Signal, 10)
+	handler.(SignalRegistrar).AddSignal(channelTwo)
+
+	channelThree := make(chan *Signal, 2)
+	handler.(SignalRegistrar).AddSignal(channelThree)
+
+	writeSignals(handler, 1000)
+
+	handler.(SignalRegistrar).RemoveSignal(channelTwo)
+	defer close(channelTwo)
+
+	count, closed := countSignals(channelTwo)
+	if count > 10 {
+		t.Error("handler continued writing to channel after removal")
+	}
+	if closed {
+		t.Error("handler closed channel on .RemoveChannel()")
+	}
+
+	// Check that closing channel two does not close channel one.
+	if err := readSignals(t, channelOne, 1000); err != nil {
+		t.Error(err)
+	}
+
+	// Check that closing channel two does not close channel three.
+	if err := readSignals(t, channelThree, 1000); err != nil {
+		t.Error(err)
+	}
+}
+
+// Test that Terminate() closes all channels that were attached at the time.
+func TestSequentialHandler_TerminateClosesAllChannels(t *testing.T) {
+	t.Parallel()
+	handler := NewSequentialSignalHandler()
+
+	channelOne := make(chan *Signal)
+	handler.(SignalRegistrar).AddSignal(channelOne)
+
+	channelTwo := make(chan *Signal, 10)
+	handler.(SignalRegistrar).AddSignal(channelTwo)
+
+	writeSignals(handler, 1000)
+
+	handler.(Terminator).Terminate()
+
+	count, closed := countSignals(channelOne)
+	if count > 1 {
+		t.Errorf("handler continued writing to channel after termination; read %v signals", count)
+	}
+	if !closed {
+		t.Error("handler failed to close channel on .Terminate()")
+	}
+
+	count, closed = countSignals(channelTwo)
+	if count > 10 {
+		t.Errorf("handler continued writing to channel after termination; read %v signals", count)
+	}
+	if !closed {
+		t.Error("handler failed to close channel on .Terminate()")
+	}
+}
+
+// Verifies that after termination, the handler does not process any further signals.
+func TestSequentialHandler_TerminateTerminates(t *testing.T) {
+	t.Parallel()
+	handler := NewSequentialSignalHandler()
+	handler.(Terminator).Terminate()
+
+	channelOne := make(chan *Signal)
+	handler.(SignalRegistrar).AddSignal(channelOne)
+
+	writeSignals(handler, 10)
+
+	count, _ := countSignals(channelOne)
+	if count > 0 {
+		t.Errorf("handler continued operating after termination; read %v signals", count)
+	}
+}
+
+// Verifies calling .Terminate() more than once is equivalent to calling it just once.
+func TestSequentialHandler_TerminateIdemopotent(t *testing.T) {
+	t.Parallel()
+	handler := NewSequentialSignalHandler()
+	handler.(Terminator).Terminate()
+	handler.(Terminator).Terminate()
+
+	channelOne := make(chan *Signal)
+	handler.(SignalRegistrar).AddSignal(channelOne)
+	writeSignals(handler, 10)
+
+	count, _ := countSignals(channelOne)
+	if count > 0 {
+		t.Errorf("handler continued operating after termination; read %v signals", count)
+	}
+}
+
+// Verifies calling RemoveSignal after Terminate() does not cause any unusual
+// behaviour (panics, etc.).
+func TestSequentialHandler_RemoveAfterTerminate(t *testing.T) {
+	t.Parallel()
+	handler := NewSequentialSignalHandler()
+	handler.(Terminator).Terminate()
+	handler.(Terminator).Terminate()
+
+	channelOne := make(chan *Signal)
+	handler.(SignalRegistrar).AddSignal(channelOne)
+	handler.(SignalRegistrar).RemoveSignal(channelOne)
+	writeSignals(handler, 10)
+
+	count, _ := countSignals(channelOne)
+	if count > 0 {
+		t.Errorf("handler continued operating after termination; read %v signals", count)
+	}
+}
+
+func writeSignals(handler SignalHandler, count int) {
+	for i := 1; i <= count; i++ {
+		signal := &Signal{Sequence: Sequence(i)}
+		handler.DeliverSignal("iface", "name", signal)
+	}
+}
+
+func readSignals(t *testing.T, channel <-chan *Signal, count int) error {
+	// Overly generous timeout
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
+	defer cancel()
+	for i := 1; i <= count; i++ {
+		select {
+		case signal := <-channel:
+			if signal.Sequence != Sequence(i) {
+				return fmt.Errorf("Received signal out of order. Expected %v, got %v", i, signal.Sequence)
+			}
+		case <-ctx.Done():
+			return errors.New("Timeout occured before all messages received")
+		}
+	}
+	return nil
+}
+
+func countSignals(channel <-chan *Signal) (count int, closed bool) {
+	count = 0
+	ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond*100)
+	defer cancel()
+	for {
+		select {
+		case _, ok := <-channel:
+			if ok {
+				count++
+			} else {
+				// Channel closed
+				return count, true
+			}
+		case <-ctx.Done():
+			return count, false
+		}
+	}
+}


### PR DESCRIPTION
Fixes #187.

This is a prototype of my proposed solution, with tests. I am unsure about the naming of external interface members and whether additional changes should be made to the external interface (other than adding Signal.Sequence and Call.ResponseSequence).

If you are completely happy with this change, please merge, otherwise please provide feedback and I will address.

Thanks,
Patrick