### PR TITLE
Allow the Store for Variants and Properties.

### DIFF
--- a/variant.go
+++ b/variant.go
@@ -142,3 +142,9 @@ func (v Variant) String() string {
 func (v Variant) Value() interface{} {
 	return v.value
 }
+
+// Store converts the variant into a native go type using the same
+// mechanism as the "Store" function.
+func (v Variant) Store(value interface{}) error {
+	return storeInterfaces(v.value, value)
+}

--- a/variant_test.go
+++ b/variant_test.go
@@ -76,3 +76,17 @@ func TestParseVariant(t *testing.T) {
 		}
 	}
 }
+
+func TestVariantStore(t *testing.T) {
+	str := "foo bar"
+	v := MakeVariant(str)
+	var result string
+	err := v.Store(&result)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result != str {
+		t.Fatalf("expected %s, got %s\n", str, result)
+	}
+
+}


### PR DESCRIPTION
This adds a Store method to Variants so that they may be easily
unmarshalled into native go types. It also adds a StoreProperty method
that can be used to directly unmarshal a value returned from
org.freedesktop.DBus.Properties.Get instead of requiring it go through
a Variant first.

Fixes #191 #197