### PR TITLE
Add ExportAll option so objects can ignore *Error requirement

### DIFF
--- a/dbus.go
+++ b/dbus.go
@@ -28,6 +28,7 @@ var (
 	interfaceType   = reflect.TypeOf((*interface{})(nil)).Elem()
 	unixFDType      = reflect.TypeOf(UnixFD(0))
 	unixFDIndexType = reflect.TypeOf(UnixFDIndex(0))
+	errType         = reflect.TypeOf((*error)(nil)).Elem()
 )
 
 // An InvalidTypeError signals that a value which cannot be represented in the

--- a/default_handler.go
+++ b/default_handler.go
@@ -151,7 +151,7 @@ func (m exportedMethod) Call(args ...interface{}) ([]interface{}, error) {
 		//concrete type to interface nil is a special case
 		return out, nil
 	}
-	return out, err.(error)
+	return out, err
 }
 
 func (m exportedMethod) NumArguments() int {

--- a/default_handler.go
+++ b/default_handler.go
@@ -147,7 +147,7 @@ func (m exportedMethod) Call(args ...interface{}) ([]interface{}, error) {
 	for i, val := range ret {
 		out[i] = val.Interface()
 	}
-	if nilErr {
+	if nilErr || err == nil {
 		//concrete type to interface nil is a special case
 		return out, nil
 	}

--- a/default_handler.go
+++ b/default_handler.go
@@ -133,7 +133,7 @@ func (m exportedMethod) Call(args ...interface{}) ([]interface{}, error) {
 			nilErr = ret[t.NumOut()-1].IsNil()
 			ret = ret[:t.NumOut()-1]
 			err = e
-		} else if ret[t.NumOut()-1].Type().Implements(reflect.TypeOf((*error)(nil)).Elem()) { // Go error
+		} else if ret[t.NumOut()-1].Type().Implements(errType) { // Go error
 			i := ret[t.NumOut()-1].Interface()
 			if i == nil {
 				nilErr = ret[t.NumOut()-1].IsNil()


### PR DESCRIPTION
I allowed developers to end with `error` so they can still return errors if that is desirable.

Fixes #55 