### PR TITLE
Add AddMatchSignal and RemoveMatchSignal versions that accept a context

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -586,8 +586,14 @@ func (conn *Conn) sendReply(dest string, serial uint32, values ...interface{}) {
 // AddMatchSignal registers the given match rule to receive broadcast
 // signals based on their contents.
 func (conn *Conn) AddMatchSignal(options ...MatchOption) error {
+	return conn.AddMatchSignalContext(context.Background(), options...)
+}
+
+// AddMatchSignalContext acts like AddMatchSignal but takes a context.
+func (conn *Conn) AddMatchSignalContext(ctx context.Context, options ...MatchOption) error {
 	options = append([]MatchOption{withMatchType("signal")}, options...)
-	return conn.busObj.Call(
+	return conn.busObj.CallWithContext(
+		ctx,
 		"org.freedesktop.DBus.AddMatch", 0,
 		formatMatchOptions(options),
 	).Store()
@@ -595,8 +601,14 @@ func (conn *Conn) AddMatchSignal(options ...MatchOption) error {
 
 // RemoveMatchSignal removes the first rule that matches previously registered with AddMatchSignal.
 func (conn *Conn) RemoveMatchSignal(options ...MatchOption) error {
+	return conn.RemoveMatchSignalContext(context.Background(), options...)
+}
+
+// RemoveMatchSignalContext acts like RemoveMatchSignal but takes a context.
+func (conn *Conn) RemoveMatchSignalContext(ctx context.Context, options ...MatchOption) error {
 	options = append([]MatchOption{withMatchType("signal")}, options...)
-	return conn.busObj.Call(
+	return conn.busObj.CallWithContext(
+		ctx,
 		"org.freedesktop.DBus.RemoveMatch", 0,
 		formatMatchOptions(options),
 	).Store()


### PR DESCRIPTION
This adds AddMatchSignalContext(), RemoveMatchSignalContext() to allow
passing a context to the underlying DBus call. Even though AddMatch is
not a long running call, this is handy when
subscribing to signals from request context or while debugging
connection issues.

Please let me know if you have any issues with this pull request.