### PR TITLE
conn: centralise (most) serial handling to sendMessageAndIfClosed

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -499,7 +499,7 @@ func (conn *Conn) send(ctx context.Context, msg *Message, ch chan *Call) *Call {
 		panic("nil context")
 	}
 	if ch == nil {
-		ch = make(chan *Call, 5)
+		ch = make(chan *Call, 1)
 	} else if cap(ch) == 0 {
 		panic("dbus: unbuffered channel passed to (*Conn).Send")
 	}

--- a/conn_test.go
+++ b/conn_test.go
@@ -461,7 +461,6 @@ process:
 				t.Logf("Processing reply to .State(), returning state = %v", state)
 				reply := new(Message)
 				reply.Type = TypeMethodReply
-				reply.serial = srv.getSerial()
 				reply.Headers = make(map[HeaderField]Variant)
 				reply.Headers[FieldDestination] = msg.Headers[FieldSender]
 				reply.Headers[FieldReplySerial] = MakeVariant(msg.serial)

--- a/export.go
+++ b/export.go
@@ -175,7 +175,6 @@ func (conn *Conn) handleCall(msg *Message) {
 	if msg.Flags&FlagNoReplyExpected == 0 {
 		reply := new(Message)
 		reply.Type = TypeMethodReply
-		reply.serial = conn.getSerial()
 		reply.Headers = make(map[HeaderField]Variant)
 		if hasSender {
 			reply.Headers[FieldDestination] = msg.Headers[FieldSender]
@@ -211,7 +210,6 @@ func (conn *Conn) Emit(path ObjectPath, name string, values ...interface{}) erro
 	}
 	msg := new(Message)
 	msg.Type = TypeSignal
-	msg.serial = conn.getSerial()
 	msg.Headers = make(map[HeaderField]Variant)
 	msg.Headers[FieldInterface] = MakeVariant(iface)
 	msg.Headers[FieldMember] = MakeVariant(member)


### PR DESCRIPTION
Previously all code creating messages also had to assign serial numbers to those messages.  With this change, `Conn.sendMessageAndIfClosed()` will assign a serial number to any message whose serial number is 0 (which is
invalid as per the spec).

The `Conn.send()` method (used to send method calls) still manually sets the serial number so it can set up the Call struct to receive the response.

`Object.createCall()` has also been simplified to make use of `Conn.SendWithContext` rather than repeating its logic.