### PR TITLE
sequential_handler: simplify to use less goroutines

### DIFF
--- a/sequential_handler.go
+++ b/sequential_handler.go
@@ -51,11 +51,7 @@ func (sh *sequentialSignalHandler) AddSignal(ch chan<- *Signal) {
 	if sh.closed {
 		return
 	}
-	sh.signals = append(sh.signals, &sequentialSignalChannelData{
-		queue: list.New(),
-		ch:    ch,
-		done:  make(chan struct{}),
-	})
+	sh.signals = append(sh.signals, newSequentialSignalChannelData(ch))
 }
 
 func (sh *sequentialSignalHandler) RemoveSignal(ch chan<- *Signal) {
@@ -75,46 +71,64 @@ func (sh *sequentialSignalHandler) RemoveSignal(ch chan<- *Signal) {
 }
 
 type sequentialSignalChannelData struct {
-	stateLock sync.Mutex
-	writeLock sync.Mutex
-	queue     *list.List
-	wg        sync.WaitGroup
-	ch        chan<- *Signal
-	done      chan struct{}
+	ch   chan<- *Signal
+	in   chan *Signal
+	done chan struct{}
 }
 
-func (scd *sequentialSignalChannelData) deliver(signal *Signal) {
-	// Avoid blocking the main DBus message processing routine;
-	// queue signal to be dispatched later.
-	scd.stateLock.Lock()
-	scd.queue.PushBack(signal)
-	scd.stateLock.Unlock()
-
-	scd.wg.Add(1)
-	go scd.deferredDeliver()
+func newSequentialSignalChannelData(ch chan<- *Signal) *sequentialSignalChannelData {
+	scd := &sequentialSignalChannelData{
+		ch:   ch,
+		in:   make(chan *Signal),
+		done: make(chan struct{}),
+	}
+	go scd.bufferSignals()
+	return scd
 }
 
-func (scd *sequentialSignalChannelData) deferredDeliver() {
-	defer scd.wg.Done()
+func (scd *sequentialSignalChannelData) bufferSignals() {
+	var (
+		queue list.List
+		next  *Signal
+	)
+	defer close(scd.done)
 
-	// Ensure only one goroutine is in this section at once, to
-	// make sure signals are sent over ch in the order they
-	// are in the queue.
-	scd.writeLock.Lock()
-	defer scd.writeLock.Unlock()
-
-	scd.stateLock.Lock()
-	elem := scd.queue.Front()
-	scd.queue.Remove(elem)
-	scd.stateLock.Unlock()
-
-	select {
-	case scd.ch <- elem.Value.(*Signal):
-	case <-scd.done:
+	for {
+		if next == nil {
+			if queue.Len() != 0 {
+				elem := queue.Front()
+				queue.Remove(elem)
+				next = elem.Value.(*Signal)
+			} else {
+				var ok bool
+				next, ok = <-scd.in
+				if !ok {
+					return
+				}
+			}
+		}
+		select {
+		case scd.ch <- next:
+			// Signal delivered: the next signal will be
+			// picked next iteration.
+			next = nil
+		case signal, ok := <-scd.in:
+			if ok {
+				queue.PushBack(signal)
+			} else {
+				return
+			}
+		}
 	}
 }
 
+func (scd *sequentialSignalChannelData) deliver(signal *Signal) {
+	scd.in <- signal
+}
+
 func (scd *sequentialSignalChannelData) close() {
-	close(scd.done)
-	scd.wg.Wait() // wait until all spawned goroutines return
+	close(scd.in)
+	// Ensure that bufferSignals() has exited and won't attempt
+	// any future sends on scd.ch
+	<-scd.done
 }


### PR DESCRIPTION
This is an attempt to reduce the number of goroutines used by the SequentialSignalHandler implementation, which seemed to occasionally trip up the race detector in the tests.  The main changes are:

1. spin up one goroutine to handle each signal channel rather than one per signal per channel.
2. move the handling of the queue of undelivered signals into this goroutine
3. remove the locks and wait group that were serialising access to the queue, since it is now private to a single goroutine.

The third `done` channel is needed to ensure the `bufferSignals` goroutine has completed.  Without it, it's possible that the goroutine will still be stuck in the `select` call when the user closes the signal channel, leading to a panic.

I've kept the use of the list type, but it may be more effective to use a slice if we expect the number of buffered signals to be small.