### PR TITLE
Switch execution to x/sys/execabs for windows security fix

### DIFF
--- a/conn_darwin.go
+++ b/conn_darwin.go
@@ -4,13 +4,14 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"os/exec"
+
+	"golang.org/x/sys/execabs"
 )
 
 const defaultSystemBusAddress = "unix:path=/opt/local/var/run/dbus/system_bus_socket"
 
 func getSessionBusPlatformAddress() (string, error) {
-	cmd := exec.Command("launchctl", "getenv", "DBUS_LAUNCHD_SESSION_BUS_SOCKET")
+	cmd := execabs.Command("launchctl", "getenv", "DBUS_LAUNCHD_SESSION_BUS_SOCKET")
 	b, err := cmd.CombinedOutput()
 
 	if err != nil {

--- a/conn_other.go
+++ b/conn_other.go
@@ -8,16 +8,17 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
-	"os/exec"
 	"os/user"
 	"path"
 	"strings"
+
+	"golang.org/x/sys/execabs"
 )
 
-var execCommand = exec.Command
+var execCommand = execabs.Command
 
 func getSessionBusPlatformAddress() (string, error) {
-	cmd := execCommand("dbus-launch")
+	cmd := execabs.Command("dbus-launch")
 	b, err := cmd.CombinedOutput()
 
 	if err != nil {

--- a/exec_command_test.go
+++ b/exec_command_test.go
@@ -3,9 +3,10 @@ package dbus
 import (
 	"fmt"
 	"os"
-	"os/exec"
 	"strconv"
 	"testing"
+
+	"golang.org/x/sys/execabs"
 )
 
 // How to mock exec.Command for unit tests
@@ -14,10 +15,10 @@ import (
 var mockedExitStatus = 0
 var mockedStdout string
 
-func fakeExecCommand(command string, args ...string) *exec.Cmd {
+func fakeExecCommand(command string, args ...string) *execabs.Cmd {
 	cs := []string{"-test.run=TestExecCommandHelper", "--", command}
 	cs = append(cs, args...)
-	cmd := exec.Command(os.Args[0], cs...)
+	cmd := execabs.Command(os.Args[0], cs...)
 	es := strconv.Itoa(mockedExitStatus)
 	cmd.Env = []string{"GO_WANT_HELPER_PROCESS=1",
 		"STDOUT=" + mockedStdout,
@@ -43,7 +44,7 @@ DBUS_SESSION_BUS_ADDRESS=unix:abstract=/tmp/dbus-0SO9YZUBGA,guid=ac22f2f3b9d2284
 DBUS_SESSION_BUS_PID=7620
 DBUS_SESSION_BUS_WINDOWID=16777217`
 	execCommand = fakeExecCommand
-	defer func() { execCommand = exec.Command }()
+	defer func() { execCommand = execabs.Command }()
 	expOut := ""
 	expErr := "dbus: couldn't determine address of session bus"
 

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/godbus/dbus/v5
 
 go 1.12
+
+require golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c h1:F1jZWGFhYfh0Ci55sIpILtKKK8p3i2/krTr0H1rg74I=
+golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/transport_nonce_tcp_test.go
+++ b/transport_nonce_tcp_test.go
@@ -4,8 +4,9 @@ import (
 	"bufio"
 	"io/ioutil"
 	"os"
-	"os/exec"
 	"testing"
+
+	"golang.org/x/sys/execabs"
 )
 
 func TestTcpNonceConnection(t *testing.T) {
@@ -47,7 +48,7 @@ func startDaemon(t *testing.T, config string) (string, *os.Process) {
 		t.Fatal(err)
 	}
 
-	cmd := exec.Command("dbus-daemon", "--nofork", "--print-address", "--config-file", cfg.Name())
+	cmd := execabs.Command("dbus-daemon", "--nofork", "--print-address", "--config-file", cfg.Name())
 	cmd.Stderr = os.Stderr
 	out, err := cmd.StdoutPipe()
 	if err != nil {


### PR DESCRIPTION
This may or may not be relevant. Feel free to close this PR if you don't think that it is useful. I don't know how much it makes sense (or is possible) to use dbus on Windows, but I wanted to be nice and open this as part of the efforts in https://github.com/fyne-io/fyne/pull/2344. We do not use use this library on Windows in our use cases.

#### Summary of the reasoning behind this change:
The os/exec package on Windows will match the behaviour of cmd.exe by considering the local folder as a primary part of the path. This means that a malicious binary with the same name, in the current folder, would be run instead of the expected binary in the system path. Due to the backwards compat being an issue, this could not be fixed within ox/exec before Go v2. See https://blog.golang.org/path-security for more info.