### PR TITLE
Update readme

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -14,13 +14,11 @@ D-Bus message bus system.
 
 ### Installation
 
-This packages requires Go 1.7. If you installed it and set up your GOPATH, just run:
+This packages requires Go 1.12 or later. It can be installed by running the command below:
 
 ```
-go get github.com/godbus/dbus
+go get github.com/godbus/dbus/v5
 ```
-
-If you want to use the subpackages, you can install them the same way.
 
 ### Usage
 

--- a/README.md
+++ b/README.md
@@ -28,10 +28,12 @@ The complete package documentation and some simple examples are available at
 gives a short overview over the basic usage. 
 
 #### Projects using godbus
-- [notify](https://github.com/esiqveland/notify) provides desktop notifications over dbus into a library.
+- [fyne](https://github.com/fyne-io/fyne) a cross platform GUI in Go inspired by Material Design.
+- [fynedesk](https://github.com/fyne-io/fynedesk) a full desktop environment for Linux/Unix using Fyne.
 - [go-bluetooth](https://github.com/muka/go-bluetooth) provides a bluetooth client over bluez dbus API.
-- [playerbm](https://github.com/altdesktop/playerbm) a bookmark utility for media players.
 - [iwd](https://github.com/shibumi/iwd) go bindings for the internet wireless daemon "iwd".
+- [notify](https://github.com/esiqveland/notify) provides desktop notifications over dbus into a library.
+- [playerbm](https://github.com/altdesktop/playerbm) a bookmark utility for media players.
 
 Please note that the API is considered unstable for now and may change without
 further notice.


### PR DESCRIPTION
This does two things (separated cleanly with two different commits). The first commit improves and updates the installation documentation to fix https://github.com/godbus/dbus/issues/236 (sub-packages are downloaded with one go get, add v5 to download latest version and mention correct minimum Go version). Secondly, it adds [fyne](github.com/fyne-io/fyne) and [fynedesk](github.com/fyne-io/fynedesk) to the list of projects using the library. The project list was also sorted in alphabetical order and the README changed to use `.md` instead of `.markdown` as extension.

Fixes #236