### PR TITLE
examples: Add client to partner server

### DIFF
--- a/_examples/client.go
+++ b/_examples/client.go
@@ -1,0 +1,28 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/godbus/dbus/v5"
+)
+
+func main() {
+	conn, err := dbus.ConnectSessionBus()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "Failed to connect to session bus:", err)
+		os.Exit(1)
+	}
+	defer conn.Close()
+
+	var s string
+	obj := conn.Object("com.github.guelfey.Demo", "/com/github/guelfey/Demo")
+	err = obj.Call("com.github.guelfey.Demo.Foo", 0).Store(&s)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "Failed to call Foo function (is the server example running?):", err)
+		os.Exit(1)
+	}
+
+	fmt.Println("Result from calling Foo function on com.github.guelfey.Demo interface:")
+	fmt.Println(s)
+}


### PR DESCRIPTION
With the server example running, the client example may be run to connect to its Demo service and call the Foo function.