### PR TITLE
netbsd support

### DIFF
--- a/transport_unixcred_netbsd.go
+++ b/transport_unixcred_netbsd.go
@@ -1,0 +1,14 @@
+package dbus
+
+import "io"
+
+func (t *unixTransport) SendNullByte() error {
+	n, _, err := t.UnixConn.WriteMsgUnix([]byte{0}, nil, nil)
+	if err != nil {
+		return err
+	}
+	if n != 1 {
+		return io.ErrShortWrite
+	}
+	return nil
+}


### PR DESCRIPTION
copy transport_unixcred_openbsd.go for quick & easy netbsd support. it might be preferable to have a single transport_unixcred_bsd.go with a build constraint for both netbsd and openbsd, but i'm not very familiar with how this project handles such things

this causes `go test` to pass on a qemu virtual machine running NetBSD-9.2