### PR TITLE
fix: remove redundant type conversions

### DIFF
--- a/transport_unix.go
+++ b/transport_unix.go
@@ -154,17 +154,15 @@ func (t *unixTransport) ReadMessage() (*Message, error) {
 		// substitute the values in the message body (which are indices for the
 		// array receiver via OOB) with the actual values
 		for i, v := range msg.Body {
-			switch v.(type) {
+			switch index := v.(type) {
 			case UnixFDIndex:
-				j := v.(UnixFDIndex)
-				if uint32(j) >= unixfds {
+				if uint32(index) >= unixfds {
 					return nil, InvalidMessageError("invalid index for unix fd")
 				}
-				msg.Body[i] = UnixFD(fds[j])
+				msg.Body[i] = UnixFD(fds[index])
 			case []UnixFDIndex:
-				idxArray := v.([]UnixFDIndex)
-				fdArray := make([]UnixFD, len(idxArray))
-				for k, j := range idxArray {
+				fdArray := make([]UnixFD, len(index))
+				for k, j := range index {
 					if uint32(j) >= unixfds {
 						return nil, InvalidMessageError("invalid index for unix fd")
 					}


### PR DESCRIPTION
redundant type conversions