### PR TITLE
fix: fix dbus.Variant Store Method Bug

### DIFF
--- a/dbus.go
+++ b/dbus.go
@@ -124,7 +124,7 @@ func isConvertibleTo(dest, src reflect.Type) bool {
 			isConvertibleTo(dest.Elem(), src.Elem())
 	case dest.Kind() == reflect.Ptr:
 		dest = dest.Elem()
-		fallthrough
+		return isConvertibleTo(dest, src)
 	case dest.Kind() == reflect.Struct:
 		return src == interfacesType
 	default:

--- a/dbus.go
+++ b/dbus.go
@@ -122,6 +122,9 @@ func isConvertibleTo(dest, src reflect.Type) bool {
 	case dest.Kind() == reflect.Slice:
 		return src.Kind() == reflect.Slice &&
 			isConvertibleTo(dest.Elem(), src.Elem())
+	case dest.Kind() == reflect.Ptr:
+		dest = dest.Elem()
+		fallthrough
 	case dest.Kind() == reflect.Struct:
 		return src == interfacesType
 	default:

--- a/dbus_test.go
+++ b/dbus_test.go
@@ -1,6 +1,8 @@
 package dbus
 
 import (
+	"bytes"
+	"reflect"
 	"testing"
 )
 
@@ -20,5 +22,36 @@ func Test_VariantOfStruct(t *testing.T) {
 	}
 	if tester != output {
 		t.Fatalf("%v != %v\n", tester, output)
+	}
+}
+
+func Test_VariantOfSlicePtr(t *testing.T) {
+	value := []TestStruct{{1, "1"}}
+	dest := []*TestStruct{}
+
+	parm := &Message{
+		Type:  TypeMethodCall,
+		Flags: FlagNoAutoStart,
+		Headers: map[HeaderField]Variant{
+			FieldPath:        MakeVariant(ObjectPath("/example")),
+			FieldDestination: MakeVariant(""),
+			FieldMember:      MakeVariant("call"),
+		},
+		Body: []interface{}{value},
+	}
+	parm.Headers[FieldSignature] = MakeVariant(SignatureOf(parm.Body...))
+	buf := new(bytes.Buffer)
+	err := parm.EncodeTo(buf, nativeEndian)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	msg, err := DecodeMessage(buf)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := Store(msg.Body, &dest); err != nil || reflect.DeepEqual(value, dest) {
+		t.Log(err)
+		t.FailNow()
 	}
 }


### PR DESCRIPTION
when Store Method Parm is []*struct type,it work not well
because in isConvertibleTo Func, it not conside Kind is ptr
and elem is struct condition

I add a switch case to transform type