### PR TITLE
Fix a data race between Conn creation and its automatic closing

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -284,10 +284,6 @@ func newConn(tr transport, opts ...ConnOption) (*Conn, error) {
 		conn.ctx = context.Background()
 	}
 	conn.ctx, conn.cancelCtx = context.WithCancel(conn.ctx)
-	go func() {
-		<-conn.ctx.Done()
-		conn.Close()
-	}()
 
 	conn.calls = newCallTracker()
 	if conn.handler == nil {
@@ -302,6 +298,11 @@ func newConn(tr transport, opts ...ConnOption) (*Conn, error) {
 	conn.outHandler = &outputHandler{conn: conn}
 	conn.names = newNameTracker()
 	conn.busObj = conn.Object("org.freedesktop.DBus", "/org/freedesktop/DBus")
+
+	go func() {
+		<-conn.ctx.Done()
+		conn.Close()
+	}()
 	return conn, nil
 }
 


### PR DESCRIPTION
`go test -race .` detects a data race when a Conn instance is automatically
closed when the provided context's deadline is missed.

Fix the data race by launching the corresponding goroutine only after all
Conn's fields had been initialized.