### PR TITLE
store: fix shrinking slice during store

### DIFF
--- a/dbus.go
+++ b/dbus.go
@@ -277,13 +277,8 @@ func storeSliceIntoInterface(dest, src reflect.Value) error {
 func storeSliceIntoSlice(dest, src reflect.Value) error {
 	if dest.IsNil() || dest.Len() < src.Len() {
 		dest.Set(reflect.MakeSlice(dest.Type(), src.Len(), src.Cap()))
-	}
-	if dest.Len() != src.Len() {
-		return fmt.Errorf(
-			"dbus.Store: type mismatch: "+
-				"slices are different lengths "+
-				"need: %d have: %d",
-			src.Len(), dest.Len())
+	} else if dest.Len() > src.Len() {
+		dest.Set(dest.Slice(0, src.Len()))
 	}
 	for i := 0; i < src.Len(); i++ {
 		err := store(dest.Index(i), getVariantValue(src.Index(i)))

--- a/store_test.go
+++ b/store_test.go
@@ -97,3 +97,18 @@ func TestStoreNested(t *testing.T) {
 			dest, src)
 	}
 }
+
+func TestStoreSmallerSliceToLargerSlice(t *testing.T) {
+	src := []string{"baz"}
+	dest := []interface{}{"foo", "bar"}
+	err := Store([]interface{}{src}, &dest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(dest) != 1 {
+		t.Fatal("Expected dest slice to shrink")
+	}
+	if dest[0].(string) != "baz" {
+		t.Fatal("Wrong element saved in dest slice")
+	}
+}


### PR DESCRIPTION
This allows storing a larger slice into a smaller slice, which would
previously be an invalid operation.

Fixes #287