### PR TITLE
Implement json/gob interfaces

### DIFF
--- a/sig.go
+++ b/sig.go
@@ -1,6 +1,9 @@
 package dbus
 
 import (
+	"bytes"
+	"encoding/gob"
+	"encoding/json"
 	"fmt"
 	"reflect"
 	"strings"
@@ -162,6 +165,29 @@ func (s Signature) Single() bool {
 // String returns the signature's string representation.
 func (s Signature) String() string {
 	return s.str
+}
+
+func (s Signature) MarshalJSON() ([]byte, error) {
+	return json.Marshal(s.String())
+}
+
+func (s *Signature) UnmarshalJSON(bytes []byte) error {
+	s.str = string(bytes)
+	return nil
+}
+
+func (s Signature) GobEncode() ([]byte, error) {
+	var buffer bytes.Buffer
+	encoder := gob.NewEncoder(&buffer)
+	if err := encoder.Encode(s.String()); err != nil {
+		return nil, err
+	}
+	return buffer.Bytes(), nil
+}
+
+func (s *Signature) GobDecode(bytes []byte) error {
+	s.str = string(bytes)
+	return nil
 }
 
 // A SignatureError indicates that a signature passed to a function or received

--- a/sig.go
+++ b/sig.go
@@ -167,15 +167,18 @@ func (s Signature) String() string {
 	return s.str
 }
 
+// MarshalJSON is to implement the interface json.Marshal
 func (s Signature) MarshalJSON() ([]byte, error) {
 	return json.Marshal(s.String())
 }
 
+// UnmarshalJSON is to implement the interface json.Unmarshal
 func (s *Signature) UnmarshalJSON(bytes []byte) error {
 	s.str = string(bytes)
 	return nil
 }
 
+// GobEncode is to implement the interface Encode in gob
 func (s Signature) GobEncode() ([]byte, error) {
 	var buffer bytes.Buffer
 	encoder := gob.NewEncoder(&buffer)
@@ -185,6 +188,7 @@ func (s Signature) GobEncode() ([]byte, error) {
 	return buffer.Bytes(), nil
 }
 
+// GobDecode is to implement the interface Decode in gob
 func (s *Signature) GobDecode(bytes []byte) error {
 	s.str = string(bytes)
 	return nil

--- a/variant.go
+++ b/variant.go
@@ -151,6 +151,7 @@ func (v Variant) Store(value interface{}) error {
 	return storeInterfaces(v.value, value)
 }
 
+// toMap trans the Variant to a map
 func (v Variant) toMap() map[string]string {
 	mapstr := map[string]string{}
 	mapstr["sig"] = v.sig.String()
@@ -161,6 +162,7 @@ func (v Variant) toMap() map[string]string {
 	return mapstr
 }
 
+// parseMap parses a Variant from a map
 func (v *Variant) parseMap(mapstr map[string]string) error {
 	if sigStr, ok := mapstr["sig"]; ok {
 		sig := Signature{sigStr}
@@ -177,11 +179,13 @@ func (v *Variant) parseMap(mapstr map[string]string) error {
 	return nil
 }
 
+// MarshalJSON is to implement the interface json.Marshal
 func (v Variant) MarshalJSON() ([]byte, error) {
 	mapstr := v.toMap()
 	return json.Marshal(mapstr)
 }
 
+// UnmarshalJSON is to implement the interface json.Unmarshal
 func (v *Variant) UnmarshalJSON(bytes []byte) error {
 	var mapstr map[string]string
 	if err := json.Unmarshal(bytes, &mapstr); err != nil {
@@ -190,6 +194,7 @@ func (v *Variant) UnmarshalJSON(bytes []byte) error {
 	return v.parseMap(mapstr)
 }
 
+// GobEncode is to implement the interface Encode in gob
 func (v Variant) GobEncode() ([]byte, error) {
 	var buffer bytes.Buffer
 	encoder := gob.NewEncoder(&buffer)
@@ -203,6 +208,7 @@ func (v Variant) GobEncode() ([]byte, error) {
 	return buffer.Bytes(), nil
 }
 
+// GobDecode is to implement the interface Decode in gob
 func (v *Variant) GobDecode(jsonBytes []byte) error {
 	buffer := bytes.NewBuffer(jsonBytes)
 	decoder := gob.NewDecoder(buffer)

--- a/variant.go
+++ b/variant.go
@@ -2,6 +2,8 @@ package dbus
 
 import (
 	"bytes"
+	"encoding/gob"
+	"encoding/json"
 	"fmt"
 	"reflect"
 	"sort"
@@ -147,4 +149,68 @@ func (v Variant) Value() interface{} {
 // mechanism as the "Store" function.
 func (v Variant) Store(value interface{}) error {
 	return storeInterfaces(v.value, value)
+}
+
+func (v Variant) toMap() map[string]string {
+	mapstr := map[string]string{}
+	mapstr["sig"] = v.sig.String()
+
+	s, _ := v.format()
+	mapstr["value"] = s
+
+	return mapstr
+}
+
+func (v *Variant) parseMap(mapstr map[string]string) error {
+	if sigStr, ok := mapstr["sig"]; ok {
+		sig := Signature{sigStr}
+
+		if vstr, ok := mapstr["value"]; ok {
+			v1, err := ParseVariant(vstr, sig)
+			if err != nil {
+				return err
+			}
+			v.sig = v1.sig
+			v.value = v1.value
+		}
+	}
+	return nil
+}
+
+func (v Variant) MarshalJSON() ([]byte, error) {
+	mapstr := v.toMap()
+	return json.Marshal(mapstr)
+}
+
+func (v *Variant) UnmarshalJSON(bytes []byte) error {
+	var mapstr map[string]string
+	if err := json.Unmarshal(bytes, &mapstr); err != nil {
+		return err
+	}
+	return v.parseMap(mapstr)
+}
+
+func (v Variant) GobEncode() ([]byte, error) {
+	var buffer bytes.Buffer
+	encoder := gob.NewEncoder(&buffer)
+
+	mapstr := v.toMap()
+
+	if err := encoder.Encode(mapstr); err != nil {
+		return nil, err
+	}
+
+	return buffer.Bytes(), nil
+}
+
+func (v *Variant) GobDecode(jsonBytes []byte) error {
+	buffer := bytes.NewBuffer(jsonBytes)
+	decoder := gob.NewDecoder(buffer)
+
+	var mapstr map[string]string
+	if err := decoder.Decode(&mapstr); err != nil {
+		return err
+	}
+
+	return v.parseMap(mapstr)
 }


### PR DESCRIPTION
close #306 

After this patch, we can use `json.Marshal`, `json.UnMarshal`, `GobEncode`, and `GobDecode` for a `Variant` variable.
