### PR TITLE
Fix default golangci-lint warnings, add it to GHA

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,6 +8,17 @@ on:
 
 jobs:
 
+  lint:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-go@v2
+        with:
+          go-version: 1.x # Latest stable version.
+      - uses: golangci/golangci-lint-action@v3
+        with:
+          version: v1.44
+
   test:
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,7 @@ jobs:
         go-version: ${{ matrix.go-version }}
 
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Install dbus
       run: sudo apt-get install dbus dbus-x11
@@ -39,7 +39,7 @@ jobs:
   codespell:
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: install deps
       # Version of codespell bundled with Ubuntu is way old, so use pip.
       run: pip install codespell

--- a/call.go
+++ b/call.go
@@ -2,10 +2,7 @@ package dbus
 
 import (
 	"context"
-	"errors"
 )
-
-var errSignature = errors.New("dbus: mismatched signature")
 
 // Call represents a pending or completed method call.
 type Call struct {

--- a/conn.go
+++ b/conn.go
@@ -941,17 +941,6 @@ func (tracker *callTracker) handleSendError(msg *Message, err error) {
 	}
 }
 
-// finalize was the only func that did not strobe Done
-func (tracker *callTracker) finalize(sn uint32) {
-	tracker.lck.Lock()
-	defer tracker.lck.Unlock()
-	c, ok := tracker.calls[sn]
-	if ok {
-		delete(tracker.calls, sn)
-		c.ContextCancel()
-	}
-}
-
 func (tracker *callTracker) finalizeWithBody(sn uint32, sequence Sequence, body []interface{}) {
 	tracker.lck.Lock()
 	c, ok := tracker.calls[sn]

--- a/conn_other.go
+++ b/conn_other.go
@@ -1,3 +1,4 @@
+//go:build !darwin
 // +build !darwin
 
 package dbus

--- a/conn_test.go
+++ b/conn_test.go
@@ -127,13 +127,12 @@ func TestRemoveSignal(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	signals := bus.signalHandler.(*defaultSignalHandler).signals
 	ch := make(chan *Signal)
 	ch2 := make(chan *Signal)
 	for _, ch := range []chan *Signal{ch, ch2, ch, ch2, ch2, ch} {
 		bus.Signal(ch)
 	}
-	signals = bus.signalHandler.(*defaultSignalHandler).signals
+	signals := bus.signalHandler.(*defaultSignalHandler).signals
 	if len(signals) != 6 {
 		t.Errorf("remove signal: signals length not equal: got '%d', want '6'", len(signals))
 	}

--- a/conn_test.go
+++ b/conn_test.go
@@ -156,8 +156,7 @@ type rwc struct {
 
 func (rwc) Close() error { return nil }
 
-type fakeAuth struct {
-}
+type fakeAuth struct{}
 
 func (fakeAuth) FirstData() (name, resp []byte, status AuthStatus) {
 	return []byte("name"), []byte("resp"), AuthOk
@@ -660,7 +659,8 @@ func benchmarkServeAsync(b *testing.B, srv, cli *Conn) {
 		for i := 0; i < b.N; i++ {
 			v := <-c
 			if v.Err != nil {
-				b.Fatal(v.Err)
+				b.Error(v.Err)
+				return
 			}
 			i, r := v.Args[0].(int64), v.Body[0].(int64)
 			if 2*i != r {

--- a/conn_test.go
+++ b/conn_test.go
@@ -633,9 +633,13 @@ func BenchmarkServeSameConnAsync(b *testing.B) {
 
 func benchmarkServe(b *testing.B, srv, cli *Conn) {
 	var r int64
-	var err error
+
+	err := srv.Export(server{}, "/org/guelfey/DBus/Test", "org.guelfey.DBus.Test")
+	if err != nil {
+		b.Fatal(err)
+	}
+
 	dest := srv.Names()[0]
-	srv.Export(server{}, "/org/guelfey/DBus/Test", "org.guelfey.DBus.Test")
 	obj := cli.Object(dest, "/org/guelfey/DBus/Test")
 	b.StartTimer()
 	for i := 0; i < b.N; i++ {
@@ -651,7 +655,10 @@ func benchmarkServe(b *testing.B, srv, cli *Conn) {
 
 func benchmarkServeAsync(b *testing.B, srv, cli *Conn) {
 	dest := srv.Names()[0]
-	srv.Export(server{}, "/org/guelfey/DBus/Test", "org.guelfey.DBus.Test")
+	err := srv.Export(server{}, "/org/guelfey/DBus/Test", "org.guelfey.DBus.Test")
+	if err != nil {
+		b.Fatal(err)
+	}
 	obj := cli.Object(dest, "/org/guelfey/DBus/Test")
 	c := make(chan *Call, 50)
 	done := make(chan struct{})

--- a/conn_test.go
+++ b/conn_test.go
@@ -361,10 +361,10 @@ const (
 
 func TestStateCachingProxyPattern(t *testing.T) {
 	srv, err := ConnectSessionBus()
-	defer srv.Close()
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer srv.Close()
 
 	conn, err := ConnectSessionBus(WithSignalHandler(NewSequentialSignalHandler()))
 	if err != nil {

--- a/conn_unix.go
+++ b/conn_unix.go
@@ -1,4 +1,5 @@
-//+build !windows,!solaris,!darwin
+//go:build !windows && !solaris && !darwin
+// +build !windows,!solaris,!darwin
 
 package dbus
 

--- a/conn_windows.go
+++ b/conn_windows.go
@@ -1,5 +1,3 @@
-//+build windows
-
 package dbus
 
 import "os"

--- a/dbus.go
+++ b/dbus.go
@@ -10,11 +10,8 @@ import (
 var (
 	byteType        = reflect.TypeOf(byte(0))
 	boolType        = reflect.TypeOf(false)
-	uint8Type       = reflect.TypeOf(uint8(0))
 	int16Type       = reflect.TypeOf(int16(0))
 	uint16Type      = reflect.TypeOf(uint16(0))
-	intType         = reflect.TypeOf(int(0))
-	uintType        = reflect.TypeOf(uint(0))
 	int32Type       = reflect.TypeOf(int32(0))
 	uint32Type      = reflect.TypeOf(uint32(0))
 	int64Type       = reflect.TypeOf(int64(0))

--- a/decoder_test.go
+++ b/decoder_test.go
@@ -65,7 +65,7 @@ func TestDecodeArrayEmptyStruct(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	msg, err = DecodeMessage(buf)
+	_, err = DecodeMessage(buf)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/decoder_test.go
+++ b/decoder_test.go
@@ -25,19 +25,19 @@ func TestDecodeArrayEmptyStruct(t *testing.T) {
 		Type:  0x02,
 		Flags: 0x00,
 		Headers: map[HeaderField]Variant{
-			0x06: Variant{
+			0x06: {
 				sig: Signature{
 					str: "s",
 				},
 				value: ":1.391",
 			},
-			0x05: Variant{
+			0x05: {
 				sig: Signature{
 					str: "u",
 				},
 				value: uint32(2),
 			},
-			0x08: Variant{
+			0x08: {
 				sig: Signature{
 					str: "g",
 				},

--- a/default_handler.go
+++ b/default_handler.go
@@ -215,10 +215,6 @@ func (obj *exportedObj) LookupMethod(name string) (Method, bool) {
 	return nil, false
 }
 
-func (obj *exportedObj) isFallbackInterface() bool {
-	return false
-}
-
 func newExportedIntf(methods map[string]Method, includeSubtree bool) *exportedIntf {
 	return &exportedIntf{
 		methods:        methods,

--- a/encoder_test.go
+++ b/encoder_test.go
@@ -42,7 +42,9 @@ func TestEncodeArrayOfMaps(t *testing.T) {
 			buf := new(bytes.Buffer)
 			fds := make([]int, 0)
 			enc := newEncoder(buf, order, fds)
-			enc.Encode(tt.vs...)
+			if err := enc.Encode(tt.vs...); err != nil {
+				t.Fatal(err)
+			}
 
 			dec := newDecoder(buf, order, enc.fds)
 			v, err := dec.Decode(SignatureOf(tt.vs...))
@@ -75,7 +77,9 @@ func TestEncodeMapStringInterface(t *testing.T) {
 		t.Fatal(err)
 	}
 	out := map[string]interface{}{}
-	Store(v, &out)
+	if err := Store(v, &out); err != nil {
+		t.Fatal(err)
+	}
 	if !reflect.DeepEqual(out, val) {
 		t.Errorf("not equal: got '%v', want '%v'",
 			out, val)
@@ -101,7 +105,9 @@ func TestEncodeMapStringNamedInterface(t *testing.T) {
 		t.Fatal(err)
 	}
 	out := map[string]empty{}
-	Store(v, &out)
+	if err := Store(v, &out); err != nil {
+		t.Fatal(err)
+	}
 	if !reflect.DeepEqual(out, val) {
 		t.Errorf("not equal: got '%v', want '%v'",
 			out, val)
@@ -156,7 +162,9 @@ func TestEncodeSliceInterface(t *testing.T) {
 		t.Fatal(err)
 	}
 	out := []interface{}{}
-	Store(v, &out)
+	if err := Store(v, &out); err != nil {
+		t.Fatal(err)
+	}
 	if !reflect.DeepEqual(out, val) {
 		t.Errorf("not equal: got '%v', want '%v'",
 			out, val)
@@ -180,7 +188,9 @@ func TestEncodeSliceNamedInterface(t *testing.T) {
 		t.Fatal(err)
 	}
 	out := []empty{}
-	Store(v, &out)
+	if err := Store(v, &out); err != nil {
+		t.Fatal(err)
+	}
 	if !reflect.DeepEqual(out, val) {
 		t.Errorf("not equal: got '%v', want '%v'",
 			out, val)
@@ -189,7 +199,8 @@ func TestEncodeSliceNamedInterface(t *testing.T) {
 
 func TestEncodeNestedInterface(t *testing.T) {
 	val := map[string]interface{}{
-		"foo": []interface{}{"1", "2", "3", "5",
+		"foo": []interface{}{
+			"1", "2", "3", "5",
 			map[string]interface{}{
 				"bar": "baz",
 			},
@@ -214,7 +225,9 @@ func TestEncodeNestedInterface(t *testing.T) {
 		t.Fatal(err)
 	}
 	out := map[string]interface{}{}
-	Store(v, &out)
+	if err := Store(v, &out); err != nil {
+		t.Fatal(err)
+	}
 	if !reflect.DeepEqual(out, val) {
 		t.Errorf("not equal: got '%#v', want '%#v'",
 			out, val)
@@ -238,7 +251,9 @@ func TestEncodeInt(t *testing.T) {
 		t.Fatal(err)
 	}
 	var out int
-	Store(v, &out)
+	if err := Store(v, &out); err != nil {
+		t.Fatal(err)
+	}
 	if !reflect.DeepEqual(out, val) {
 		t.Errorf("not equal: got '%v', want '%v'",
 			out, val)
@@ -286,7 +301,9 @@ func TestEncodeUint(t *testing.T) {
 		t.Fatal(err)
 	}
 	var out uint
-	Store(v, &out)
+	if err := Store(v, &out); err != nil {
+		t.Fatal(err)
+	}
 	if !reflect.DeepEqual(out, val) {
 		t.Errorf("not equal: got '%v', want '%v'",
 			out, val)
@@ -347,7 +364,7 @@ func TestEncodeOfAssignableType(t *testing.T) {
 
 func TestEncodeVariant(t *testing.T) {
 	var res map[ObjectPath]map[string]map[string]Variant
-	var src = map[ObjectPath]map[string]map[string]Variant{
+	src := map[ObjectPath]map[string]map[string]Variant{
 		ObjectPath("/foo/bar"): {
 			"foo": {
 				"bar": MakeVariant(10),
@@ -378,7 +395,7 @@ func TestEncodeVariant(t *testing.T) {
 
 func TestEncodeVariantToList(t *testing.T) {
 	var res map[string]Variant
-	var src = map[string]interface{}{
+	src := map[string]interface{}{
 		"foo": []interface{}{"a", "b", "c"},
 	}
 	buf := new(bytes.Buffer)
@@ -404,7 +421,7 @@ func TestEncodeVariantToList(t *testing.T) {
 
 func TestEncodeVariantToUint64(t *testing.T) {
 	var res map[string]Variant
-	var src = map[string]interface{}{
+	src := map[string]interface{}{
 		"foo": uint64(10),
 	}
 	buf := new(bytes.Buffer)

--- a/examples_test.go
+++ b/examples_test.go
@@ -41,15 +41,12 @@ func ExampleObject_Go() {
 
 	ch := make(chan *Call, 10)
 	conn.BusObject().Go("org.freedesktop.DBus.ListActivatableNames", 0, ch)
-	select {
-	case call := <-ch:
-		if call.Err != nil {
-			panic(err)
-		}
-		list := call.Body[0].([]string)
-		for _, v := range list {
-			fmt.Println(v)
-		}
-		// put some other cases here
+	call := <-ch
+	if call.Err != nil {
+		panic(err)
+	}
+	list := call.Body[0].([]string)
+	for _, v := range list {
+		fmt.Println(v)
 	}
 }

--- a/exec_command_test.go
+++ b/exec_command_test.go
@@ -1,7 +1,6 @@
 package dbus
 
 import (
-	"fmt"
 	"os"
 	"os/exec"
 	"strconv"
@@ -30,7 +29,7 @@ func TestExecCommandHelper(t *testing.T) {
 		return
 	}
 
-	fmt.Fprintf(os.Stdout, os.Getenv("STDOUT"))
+	t.Log(os.Getenv("STDOUT"))
 	i, _ := strconv.Atoi(os.Getenv("EXIT_STATUS"))
 	os.Exit(i)
 }

--- a/export_test.go
+++ b/export_test.go
@@ -58,7 +58,10 @@ func TestExport(t *testing.T) {
 
 	name := connection.Names()[0]
 
-	connection.Export(server{}, "/org/guelfey/DBus/Test", "org.guelfey.DBus.Test")
+	err = connection.Export(server{}, "/org/guelfey/DBus/Test", "org.guelfey.DBus.Test")
+	if err != nil {
+		t.Fatal(err)
+	}
 	object := connection.Object(name, "/org/guelfey/DBus/Test")
 	subtreeObject := connection.Object(name, "/org/guelfey/DBus/Test/Foo")
 
@@ -80,7 +83,11 @@ func TestExport(t *testing.T) {
 	}
 
 	// Now remove export
-	connection.Export(nil, "/org/guelfey/DBus/Test", "org.guelfey.DBus.Test")
+	err = connection.Export(nil, "/org/guelfey/DBus/Test", "org.guelfey.DBus.Test")
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	err = object.Call("org.guelfey.DBus.Test.Double", 0, int64(2)).Store(&response)
 	if err == nil {
 		t.Error("Expected an error since the export was removed")
@@ -98,7 +105,10 @@ func TestExport_goerror(t *testing.T) {
 	name := connection.Names()[0]
 
 	export := &errorExport{}
-	connection.ExportAll(export, "/org/guelfey/DBus/Test", "org.guelfey.DBus.Test")
+	err = connection.ExportAll(export, "/org/guelfey/DBus/Test", "org.guelfey.DBus.Test")
+	if err != nil {
+		t.Fatal(err)
+	}
 	object := connection.Object(name, "/org/guelfey/DBus/Test")
 
 	var response string
@@ -127,7 +137,10 @@ func TestExport_noerror(t *testing.T) {
 	name := connection.Names()[0]
 
 	export := &noErrorExport{}
-	connection.ExportAll(export, "/org/guelfey/DBus/Test", "org.guelfey.DBus.Test")
+	err = connection.ExportAll(export, "/org/guelfey/DBus/Test", "org.guelfey.DBus.Test")
+	if err != nil {
+		t.Fatal(err)
+	}
 	object := connection.Object(name, "/org/guelfey/DBus/Test")
 
 	var response string
@@ -156,7 +169,10 @@ func TestExport_message(t *testing.T) {
 	name := connection.Names()[0]
 
 	export := &fooExport{}
-	connection.Export(export, "/org/guelfey/DBus/Test", "org.guelfey.DBus.Test")
+	err = connection.Export(export, "/org/guelfey/DBus/Test", "org.guelfey.DBus.Test")
+	if err != nil {
+		t.Fatal(err)
+	}
 	object := connection.Object(name, "/org/guelfey/DBus/Test")
 
 	var response string
@@ -199,7 +215,10 @@ func TestExport_unexportedMethod(t *testing.T) {
 
 	name := connection.Names()[0]
 
-	connection.Export(lowerCaseExport{}, "/org/guelfey/DBus/Test", "org.guelfey.DBus.Test")
+	err = connection.Export(lowerCaseExport{}, "/org/guelfey/DBus/Test", "org.guelfey.DBus.Test")
+	if err != nil {
+		t.Fatal(err)
+	}
 	object := connection.Object(name, "/org/guelfey/DBus/Test")
 
 	var response string
@@ -221,7 +240,10 @@ func TestExport_badSignature(t *testing.T) {
 
 	name := connection.Names()[0]
 
-	connection.Export(badExport{}, "/org/guelfey/DBus/Test", "org.guelfey.DBus.Test")
+	err = connection.Export(badExport{}, "/org/guelfey/DBus/Test", "org.guelfey.DBus.Test")
+	if err != nil {
+		t.Fatal(err)
+	}
 	object := connection.Object(name, "/org/guelfey/DBus/Test")
 
 	var response string
@@ -245,7 +267,10 @@ func TestExportWithMap(t *testing.T) {
 	mapping := make(map[string]string)
 	mapping["Double"] = "double" // Export this method as lower-case
 
-	connection.ExportWithMap(server{}, mapping, "/org/guelfey/DBus/Test", "org.guelfey.DBus.Test")
+	err = connection.ExportWithMap(server{}, mapping, "/org/guelfey/DBus/Test", "org.guelfey.DBus.Test")
+	if err != nil {
+		t.Fatal(err)
+	}
 	object := connection.Object(name, "/org/guelfey/DBus/Test")
 
 	var response int64
@@ -272,7 +297,10 @@ func TestExportWithMap_bypassAlias(t *testing.T) {
 	mapping := make(map[string]string)
 	mapping["Double"] = "double" // Export this method as lower-case
 
-	connection.ExportWithMap(server{}, mapping, "/org/guelfey/DBus/Test", "org.guelfey.DBus.Test")
+	err = connection.ExportWithMap(server{}, mapping, "/org/guelfey/DBus/Test", "org.guelfey.DBus.Test")
+	if err != nil {
+		t.Fatal(err)
+	}
 	object := connection.Object(name, "/org/guelfey/DBus/Test")
 
 	var response int64
@@ -294,7 +322,10 @@ func TestExportSubtree(t *testing.T) {
 	name := connection.Names()[0]
 
 	export := &fooExport{}
-	connection.ExportSubtree(export, "/org/guelfey/DBus/Test", "org.guelfey.DBus.Test")
+	err = connection.ExportSubtree(export, "/org/guelfey/DBus/Test", "org.guelfey.DBus.Test")
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	// Call a subpath of the exported path
 	object := connection.Object(name, "/org/guelfey/DBus/Test/Foo")
@@ -314,7 +345,11 @@ func TestExportSubtree(t *testing.T) {
 	}
 
 	// Now remove export
-	connection.Export(nil, "/org/guelfey/DBus/Test", "org.guelfey.DBus.Test")
+	err = connection.Export(nil, "/org/guelfey/DBus/Test", "org.guelfey.DBus.Test")
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	err = object.Call("org.guelfey.DBus.Test.Foo", 0, "qux").Store(&response)
 	if err == nil {
 		t.Error("Expected an error since the export was removed")
@@ -332,7 +367,10 @@ func TestExportSubtree_noMessage(t *testing.T) {
 
 	name := connection.Names()[0]
 
-	connection.ExportSubtree(server{}, "/org/guelfey/DBus/Test", "org.guelfey.DBus.Test")
+	err = connection.ExportSubtree(server{}, "/org/guelfey/DBus/Test", "org.guelfey.DBus.Test")
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	// Call a subpath of the exported path
 	object := connection.Object(name, "/org/guelfey/DBus/Test/Foo")
@@ -348,7 +386,10 @@ func TestExportSubtree_noMessage(t *testing.T) {
 	}
 
 	// Now remove export
-	connection.Export(nil, "/org/guelfey/DBus/Test", "org.guelfey.DBus.Test")
+	err = connection.Export(nil, "/org/guelfey/DBus/Test", "org.guelfey.DBus.Test")
+	if err != nil {
+		t.Fatal(err)
+	}
 	err = object.Call("org.guelfey.DBus.Test.Double", 0, int64(2)).Store(&response)
 	if err == nil {
 		t.Error("Expected an error since the export was removed")
@@ -366,12 +407,18 @@ func TestExportSubtree_exportPrecedence(t *testing.T) {
 	name := connection.Names()[0]
 
 	// Register for the entire subtree of /org/guelfey/DBus/Test
-	connection.ExportSubtree(&fooExport{},
+	err = connection.ExportSubtree(&fooExport{},
 		"/org/guelfey/DBus/Test", "org.guelfey.DBus.Test")
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	// Explicitly register for /org/guelfey/DBus/Test/Foo, a subpath of above
-	connection.Export(&barExport{}, "/org/guelfey/DBus/Test/Foo",
+	err = connection.Export(&barExport{}, "/org/guelfey/DBus/Test/Foo",
 		"org.guelfey.DBus.Test")
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	// Call the explicitly exported path
 	object := connection.Object(name, "/org/guelfey/DBus/Test/Foo")
@@ -389,7 +436,11 @@ func TestExportSubtree_exportPrecedence(t *testing.T) {
 	response = "" // Reset response so errors aren't confusing
 
 	// Now remove explicit export
-	connection.Export(nil, "/org/guelfey/DBus/Test/Foo", "org.guelfey.DBus.Test")
+	err = connection.Export(nil, "/org/guelfey/DBus/Test/Foo", "org.guelfey.DBus.Test")
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	err = object.Call("org.guelfey.DBus.Test.Foo", 0, "qux").Store(&response)
 	if err != nil {
 		t.Errorf("Unexpected error calling Foo: %s", err)
@@ -414,7 +465,10 @@ func TestExportSubtreeWithMap(t *testing.T) {
 	mapping := make(map[string]string)
 	mapping["Foo"] = "foo" // Export this method as lower-case
 
-	connection.ExportSubtreeWithMap(&fooExport{}, mapping, "/org/guelfey/DBus/Test", "org.guelfey.DBus.Test")
+	err = connection.ExportSubtreeWithMap(&fooExport{}, mapping, "/org/guelfey/DBus/Test", "org.guelfey.DBus.Test")
+	if err != nil {
+		t.Errorf("Unexpected error calling Foo: %s", err)
+	}
 
 	// Call a subpath of the exported path
 	object := connection.Object(name, "/org/guelfey/DBus/Test/Foo")
@@ -431,7 +485,11 @@ func TestExportSubtreeWithMap(t *testing.T) {
 	}
 
 	// Now remove export
-	connection.Export(nil, "/org/guelfey/DBus/Test", "org.guelfey.DBus.Test")
+	err = connection.Export(nil, "/org/guelfey/DBus/Test", "org.guelfey.DBus.Test")
+	if err != nil {
+		t.Errorf("Unexpected error calling Foo: %s", err)
+	}
+
 	err = object.Call("org.guelfey.DBus.Test.foo", 0, "qux").Store(&response)
 	if err == nil {
 		t.Error("Expected an error since the export was removed")
@@ -451,7 +509,11 @@ func TestExportSubtreeWithMap_bypassAlias(t *testing.T) {
 	mapping := make(map[string]string)
 	mapping["Foo"] = "foo" // Export this method as lower-case
 
-	connection.ExportSubtreeWithMap(&fooExport{}, mapping, "/org/guelfey/DBus/Test", "org.guelfey.DBus.Test")
+	err = connection.ExportSubtreeWithMap(&fooExport{}, mapping, "/org/guelfey/DBus/Test", "org.guelfey.DBus.Test")
+	if err != nil {
+		t.Errorf("Unexpected error calling Foo: %s", err)
+	}
+
 	object := connection.Object(name, "/org/guelfey/DBus/Test/Foo")
 
 	var response string
@@ -476,7 +538,10 @@ func TestExportMethodTable(t *testing.T) {
 		return export.Foo(message, param)
 	}
 	tbl["Foo2"] = export.Foo
-	connection.ExportMethodTable(tbl, "/org/guelfey/DBus/Test", "org.guelfey.DBus.Test")
+	err = connection.ExportMethodTable(tbl, "/org/guelfey/DBus/Test", "org.guelfey.DBus.Test")
+	if err != nil {
+		t.Errorf("Unexpected error calling Foo: %s", err)
+	}
 
 	object := connection.Object(name, "/org/guelfey/DBus/Test")
 
@@ -508,7 +573,11 @@ func TestExportMethodTable(t *testing.T) {
 	}
 
 	// Now remove export
-	connection.Export(nil, "/org/guelfey/DBus/Test", "org.guelfey.DBus.Test")
+	err = connection.Export(nil, "/org/guelfey/DBus/Test", "org.guelfey.DBus.Test")
+	if err != nil {
+		t.Errorf("Unexpected error calling Foo: %s", err)
+	}
+
 	err = object.Call("org.guelfey.DBus.Test.Foo", 0, "qux").Store(&response)
 	if err == nil {
 		t.Error("Expected an error since the export was removed")
@@ -530,7 +599,10 @@ func TestExportSubtreeMethodTable(t *testing.T) {
 		return export.Foo(message, param)
 	}
 	tbl["Foo2"] = export.Foo
-	connection.ExportSubtreeMethodTable(tbl, "/org/guelfey/DBus/Test", "org.guelfey.DBus.Test")
+	err = connection.ExportSubtreeMethodTable(tbl, "/org/guelfey/DBus/Test", "org.guelfey.DBus.Test")
+	if err != nil {
+		t.Errorf("Unexpected error calling Foo: %s", err)
+	}
 
 	// Call a subpath of the exported path
 	object := connection.Object(name, "/org/guelfey/DBus/Test/Foo")
@@ -563,7 +635,11 @@ func TestExportSubtreeMethodTable(t *testing.T) {
 	}
 
 	// Now remove export
-	connection.Export(nil, "/org/guelfey/DBus/Test", "org.guelfey.DBus.Test")
+	err = connection.Export(nil, "/org/guelfey/DBus/Test", "org.guelfey.DBus.Test")
+	if err != nil {
+		t.Errorf("Unexpected error calling Foo: %s", err)
+	}
+
 	err = object.Call("org.guelfey.DBus.Test.Foo", 0, "qux").Store(&response)
 	if err == nil {
 		t.Error("Expected an error since the export was removed")
@@ -585,7 +661,11 @@ func TestExportMethodTable_NotFunc(t *testing.T) {
 	}
 	tbl["Foo2"] = "foobar"
 
-	connection.ExportMethodTable(tbl, "/org/guelfey/DBus/Test", "org.guelfey.DBus.Test")
+	err = connection.ExportMethodTable(tbl, "/org/guelfey/DBus/Test", "org.guelfey.DBus.Test")
+	if err != nil {
+		t.Errorf("Unexpected error calling Foo: %s", err)
+	}
+
 	object := connection.Object(name, "/org/guelfey/DBus/Test")
 
 	var response string
@@ -623,7 +703,11 @@ func TestExportMethodTable_ReturnNotError(t *testing.T) {
 		return out, out
 	}
 
-	connection.ExportMethodTable(tbl, "/org/guelfey/DBus/Test", "org.guelfey.DBus.Test")
+	err = connection.ExportMethodTable(tbl, "/org/guelfey/DBus/Test", "org.guelfey.DBus.Test")
+	if err != nil {
+		t.Errorf("Unexpected error calling Foo: %s", err)
+	}
+
 	object := connection.Object(name, "/org/guelfey/DBus/Test")
 
 	var response string
@@ -675,10 +759,25 @@ func TestExportSubPathIntrospection(t *testing.T) {
 
 	foo := &fooExport{}
 	bar := &barExport{}
-	connection.Export(foo, foopathstr, test1intfstr)
-	connection.Export(foo, foopathstr, test2intfstr)
-	connection.Export(bar, barpathstr, test2intfstr)
-	connection.Export(intro, pathstr, introIntf)
+	err = connection.Export(foo, foopathstr, test1intfstr)
+	if err != nil {
+		t.Errorf("Unexpected error calling Foo: %s", err)
+	}
+
+	err = connection.Export(foo, foopathstr, test2intfstr)
+	if err != nil {
+		t.Errorf("Unexpected error calling Foo: %s", err)
+	}
+
+	err = connection.Export(bar, barpathstr, test2intfstr)
+	if err != nil {
+		t.Errorf("Unexpected error calling Foo: %s", err)
+	}
+
+	err = connection.Export(intro, pathstr, introIntf)
+	if err != nil {
+		t.Errorf("Unexpected error calling Foo: %s", err)
+	}
 
 	var response string
 	var match bool

--- a/export_test.go
+++ b/export_test.go
@@ -9,10 +9,6 @@ import (
 
 type lowerCaseExport struct{}
 
-func (export lowerCaseExport) foo() (string, *Error) {
-	return "bar", nil
-}
-
 type fooExport struct {
 	message Message
 }

--- a/export_test.go
+++ b/export_test.go
@@ -47,7 +47,7 @@ type noErrorExport struct {
 	message Message
 }
 
-func (export *noErrorExport) Run(message Message, param string) (string) {
+func (export *noErrorExport) Run(message Message, param string) string {
 	export.message = message
 	return "cool"
 }

--- a/message.go
+++ b/message.go
@@ -267,10 +267,10 @@ func (msg *Message) EncodeToWithFDs(out io.Writer, order binary.ByteOrder) (fds 
 	enc.align(8)
 	body.WriteTo(&buf)
 	if buf.Len() > 1<<27 {
-		return make([]int, 0), InvalidMessageError("message is too long")
+		return nil, InvalidMessageError("message is too long")
 	}
 	if _, err := buf.WriteTo(out); err != nil {
-		return make([]int, 0), err
+		return nil, err
 	}
 	return enc.fds, nil
 }

--- a/message.go
+++ b/message.go
@@ -158,7 +158,9 @@ func DecodeMessageWithFDs(rd io.Reader, fds []int) (msg *Message, err error) {
 	if err != nil {
 		return nil, err
 	}
-	binary.Read(bytes.NewBuffer(b), order, &hlength)
+	if err := binary.Read(bytes.NewBuffer(b), order, &hlength); err != nil {
+		return nil, err
+	}
 	if hlength+length+16 > 1<<27 {
 		return nil, InvalidMessageError("message is too long")
 	}
@@ -265,7 +267,9 @@ func (msg *Message) EncodeToWithFDs(out io.Writer, order binary.ByteOrder) (fds 
 		return
 	}
 	enc.align(8)
-	body.WriteTo(&buf)
+	if _, err := body.WriteTo(&buf); err != nil {
+		return nil, err
+	}
 	if buf.Len() > 1<<27 {
 		return nil, InvalidMessageError("message is too long")
 	}

--- a/object_test.go
+++ b/object_test.go
@@ -26,7 +26,10 @@ func TestObjectGoWithContextTimeout(t *testing.T) {
 	defer bus.Close()
 
 	name := bus.Names()[0]
-	bus.Export(objectGoContextServer{t, time.Second}, "/org/dannin/DBus/Test", "org.dannin.DBus.Test")
+	err = bus.Export(objectGoContextServer{t, time.Second}, "/org/dannin/DBus/Test", "org.dannin.DBus.Test")
+	if err != nil {
+		t.Fatal(err)
+	}
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
 	select {
@@ -47,7 +50,10 @@ func TestObjectGoWithContext(t *testing.T) {
 	defer bus.Close()
 
 	name := bus.Names()[0]
-	bus.Export(objectGoContextServer{t, time.Millisecond}, "/org/dannin/DBus/Test", "org.dannin.DBus.Test")
+	err = bus.Export(objectGoContextServer{t, time.Millisecond}, "/org/dannin/DBus/Test", "org.dannin.DBus.Test")
+	if err != nil {
+		t.Fatal(err)
+	}
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
 	select {

--- a/prop/prop_test.go
+++ b/prop/prop_test.go
@@ -18,7 +18,10 @@ func comparePropValue(obj dbus.BusObject, name string, want interface{}, t *test
 		t.Fatal(err)
 	}
 	haveValue := reflect.New(reflect.TypeOf(want)).Interface()
-	dbus.Store([]interface{}{r.Value()}, haveValue)
+	err = dbus.Store([]interface{}{r.Value()}, haveValue)
+	if err != nil {
+		t.Fatal(err)
+	}
 	have := reflect.ValueOf(haveValue).Elem().Interface()
 	if !reflect.DeepEqual(have, want) {
 		t.Errorf("struct comparison failed: got '%v', want '%v'", have, want)
@@ -78,9 +81,15 @@ func TestValidateStructsAsProp(t *testing.T) {
 	yoos := make([]Foo, 2)
 	yoos[0] = Foo{Id: 3, Value: "Threes"}
 	yoos[1] = Foo{Id: 4, Value: "Fours"}
-	obj.SetProperty("org.guelfey.DBus.Test.FooStruct", dbus.MakeVariant(yoo))
-	obj.SetProperty("org.guelfey.DBus.Test.FooStructPtr", dbus.MakeVariant(yooPtr))
-	obj.SetProperty("org.guelfey.DBus.Test.SliceOfFoos", dbus.MakeVariant(yoos))
+	if err := obj.SetProperty("org.guelfey.DBus.Test.FooStruct", dbus.MakeVariant(yoo)); err != nil {
+		t.Fatal(err)
+	}
+	if err := obj.SetProperty("org.guelfey.DBus.Test.FooStructPtr", dbus.MakeVariant(yooPtr)); err != nil {
+		t.Fatal(err)
+	}
+	if err := obj.SetProperty("org.guelfey.DBus.Test.SliceOfFoos", dbus.MakeVariant(yoos)); err != nil {
+		t.Fatal(err)
+	}
 	comparePropValue(obj, "FooStruct", yoo, t)
 	comparePropValue(obj, "FooStructPtr", *yooPtr, t)
 	comparePropValue(obj, "SliceOfFoos", yoos, t)
@@ -93,9 +102,15 @@ func TestValidateStructsAsProp(t *testing.T) {
 	zoos := make([]Foo, 2)
 	zoos[0] = Foo{Id: 5, Value: "Sevens"}
 	zoos[1] = Foo{Id: 6, Value: "Sixes"}
-	obj.SetProperty("org.guelfey.DBus.Test.FooStruct", dbus.MakeVariant(zoo))
-	obj.SetProperty("org.guelfey.DBus.Test.FooStructPtr", dbus.MakeVariant(zooPtr))
-	obj.SetProperty("org.guelfey.DBus.Test.SliceOfFoos", dbus.MakeVariant(zoos))
+	if err := obj.SetProperty("org.guelfey.DBus.Test.FooStruct", dbus.MakeVariant(zoo)); err != nil {
+		t.Fatal(err)
+	}
+	if err := obj.SetProperty("org.guelfey.DBus.Test.FooStructPtr", dbus.MakeVariant(zooPtr)); err != nil {
+		t.Fatal(err)
+	}
+	if err := obj.SetProperty("org.guelfey.DBus.Test.SliceOfFoos", dbus.MakeVariant(zoos)); err != nil {
+		t.Fatal(err)
+	}
 	comparePropValue(obj, "FooStruct", zoo, t)
 	comparePropValue(obj, "FooStructPtr", *zooPtr, t)
 	comparePropValue(obj, "SliceOfFoos", zoos, t)

--- a/proto_test.go
+++ b/proto_test.go
@@ -86,7 +86,9 @@ func TestProto(t *testing.T) {
 		buf := new(bytes.Buffer)
 		fds := make([]int, 0)
 		bigEnc := newEncoder(buf, binary.BigEndian, fds)
-		bigEnc.Encode(v.vs...)
+		if err := bigEnc.Encode(v.vs...); err != nil {
+			t.Fatal(err)
+		}
 		marshalled := buf.Bytes()
 		if !bytes.Equal(marshalled, v.bigEndian) {
 			t.Errorf("test %d (marshal be): got '%v', but expected '%v'\n", i+1, marshalled,
@@ -95,7 +97,9 @@ func TestProto(t *testing.T) {
 		buf.Reset()
 		fds = make([]int, 0)
 		litEnc := newEncoder(buf, binary.LittleEndian, fds)
-		litEnc.Encode(v.vs...)
+		if err := litEnc.Encode(v.vs...); err != nil {
+			t.Fatal(err)
+		}
 		marshalled = buf.Bytes()
 		if !bytes.Equal(marshalled, v.littleEndian) {
 			t.Errorf("test %d (marshal le): got '%v', but expected '%v'\n", i+1, marshalled,
@@ -138,7 +142,9 @@ func TestProtoMap(t *testing.T) {
 	buf := new(bytes.Buffer)
 	fds := make([]int, 0)
 	enc := newEncoder(buf, binary.LittleEndian, fds)
-	enc.Encode(m)
+	if err := enc.Encode(m); err != nil {
+		t.Fatal(err)
+	}
 	dec := newDecoder(buf, binary.LittleEndian, enc.fds)
 	vs, err := dec.Decode(Signature{"a{sy}"})
 	if err != nil {
@@ -161,7 +167,9 @@ func TestProtoVariantStruct(t *testing.T) {
 	buf := new(bytes.Buffer)
 	fds := make([]int, 0)
 	enc := newEncoder(buf, binary.LittleEndian, fds)
-	enc.Encode(v)
+	if err := enc.Encode(v); err != nil {
+		t.Fatal(err)
+	}
 	dec := newDecoder(buf, binary.LittleEndian, enc.fds)
 	vs, err := dec.Decode(Signature{"v"})
 	if err != nil {
@@ -192,7 +200,9 @@ func TestProtoStructTag(t *testing.T) {
 	buf := new(bytes.Buffer)
 	fds := make([]int, 0)
 	enc := newEncoder(buf, binary.LittleEndian, fds)
-	enc.Encode(bar1)
+	if err := enc.Encode(bar1); err != nil {
+		t.Fatal(err)
+	}
 	dec := newDecoder(buf, binary.LittleEndian, enc.fds)
 	vs, err := dec.Decode(Signature{"(ii)"})
 	if err != nil {

--- a/sequential_handler.go
+++ b/sequential_handler.go
@@ -93,7 +93,7 @@ func (scd *sequentialSignalChannelData) bufferSignals() {
 	var queue []*Signal
 	for {
 		if len(queue) == 0 {
-			signal, ok := <- scd.in
+			signal, ok := <-scd.in
 			if !ok {
 				return
 			}

--- a/server_interfaces_test.go
+++ b/server_interfaces_test.go
@@ -56,7 +56,7 @@ func newIntro(path ObjectPath) *intro {
 	return &intro{path}
 }
 
-//Handler
+// Handler
 func (t *tester) LookupObject(path ObjectPath) (ServerObject, bool) {
 	if path == "/com/github/godbus/tester" {
 		return t, true
@@ -64,7 +64,7 @@ func (t *tester) LookupObject(path ObjectPath) (ServerObject, bool) {
 	return newIntro(path), true
 }
 
-//ServerObject
+// ServerObject
 func (t *tester) LookupInterface(name string) (Interface, bool) {
 	switch name {
 	case "com.github.godbus.dbus.Tester":
@@ -76,7 +76,7 @@ func (t *tester) LookupInterface(name string) (Interface, bool) {
 	return nil, false
 }
 
-//Interface
+// Interface
 func (t *tester) LookupMethod(name string) (Method, bool) {
 	switch name {
 	case "Test":
@@ -108,7 +108,7 @@ func (t *tester) LookupMethod(name string) (Method, bool) {
 	return nil, false
 }
 
-//Method
+// Method
 func (t *tester) Call(args ...interface{}) ([]interface{}, error) {
 	return args, nil
 }
@@ -151,7 +151,7 @@ func (t terrfn) ReturnValue(position int) interface{} {
 	return ""
 }
 
-//SignalHandler
+// SignalHandler
 func (t *tester) DeliverSignal(iface, name string, signal *Signal) {
 	t.subSigsMu.Lock()
 	intf, ok := t.subSigs[iface]
@@ -441,14 +441,13 @@ func TestHandlerSignal(t *testing.T) {
 		if sig.Body[0] != "foo" {
 			t.Errorf("Unexpected signal got %s, expected %s", sig.Body[0], "foo")
 		}
-	case <-time.After(time.Second * 10): //overly generous timeout
+	case <-time.After(time.Second * 10): // overly generous timeout
 		t.Errorf("Didn't receive a signal after 10 seconds")
 	}
 	tester.Close()
 }
 
-type X struct {
-}
+type X struct{}
 
 func (x *X) Method1() *Error {
 	return nil
@@ -473,7 +472,7 @@ func TestRaceInExport(t *testing.T) {
 	go func() {
 		err = bus.Export(&x, dbusPath, dbusInterface)
 		if err != nil {
-			t.Fatal(err)
+			t.Error(err)
 		}
 		wg.Done()
 	}()

--- a/transport_nonce_tcp.go
+++ b/transport_nonce_tcp.go
@@ -1,4 +1,5 @@
-//+build !windows
+//go:build !windows
+// +build !windows
 
 package dbus
 

--- a/transport_nonce_tcp_test.go
+++ b/transport_nonce_tcp_test.go
@@ -24,7 +24,7 @@ func TestTcpNonceConnection(t *testing.T) {
 		</policy>
 </busconfig>
 `)
-	defer process.Kill()
+	defer func() { _ = process.Kill() }()
 
 	conn, err := Connect(addr, WithAuth(AuthAnonymous()))
 	if err != nil {
@@ -59,7 +59,7 @@ func startDaemon(t *testing.T, config string) (string, *os.Process) {
 	r := bufio.NewReader(out)
 	l, _, err := r.ReadLine()
 	if err != nil {
-		cmd.Process.Kill()
+		_ = cmd.Process.Kill()
 		t.Fatal(err)
 	}
 	return string(l), cmd.Process

--- a/transport_unix.go
+++ b/transport_unix.go
@@ -1,4 +1,5 @@
-//+build !windows,!solaris
+//go:build !windows && !solaris
+// +build !windows,!solaris
 
 package dbus
 

--- a/transport_unix.go
+++ b/transport_unix.go
@@ -102,8 +102,12 @@ func (t *unixTransport) ReadMessage() (*Message, error) {
 	}
 	// csheader[4:8] -> length of message body, csheader[12:16] -> length of
 	// header fields (without alignment)
-	binary.Read(bytes.NewBuffer(csheader[4:8]), order, &blen)
-	binary.Read(bytes.NewBuffer(csheader[12:]), order, &hlen)
+	if err := binary.Read(bytes.NewBuffer(csheader[4:8]), order, &blen); err != nil {
+		return nil, err
+	}
+	if err := binary.Read(bytes.NewBuffer(csheader[12:]), order, &hlen); err != nil {
+		return nil, err
+	}
 	if hlen%8 != 0 {
 		hlen += 8 - (hlen % 8)
 	}
@@ -120,7 +124,10 @@ func (t *unixTransport) ReadMessage() (*Message, error) {
 	if err != nil {
 		return nil, err
 	}
-	Store(vs, &headers)
+	err = Store(vs, &headers)
+	if err != nil {
+		return nil, err
+	}
 	for _, v := range headers {
 		if v.Field == byte(FieldUnixFDs) {
 			unixfds, _ = v.Variant.value.(uint32)

--- a/transport_unix_test.go
+++ b/transport_unix_test.go
@@ -92,7 +92,11 @@ func TestUnixFDs(t *testing.T) {
 	defer w.Close()
 	name := conn.Names()[0]
 	test := unixFDTest{t}
-	conn.Export(test, "/com/github/guelfey/test", "com.github.guelfey.test")
+	err = conn.Export(test, "/com/github/guelfey/test", "com.github.guelfey.test")
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	var s string
 	obj := conn.Object(name, "/com/github/guelfey/test")
 
@@ -150,5 +154,4 @@ func TestUnixFDs(t *testing.T) {
 	if s != testString {
 		t.Fatal("got", s, "wanted", testString)
 	}
-
 }

--- a/variant_parser.go
+++ b/variant_parser.go
@@ -417,7 +417,6 @@ func (b boolNode) Value(sig Signature) (interface{}, error) {
 type arrayNode struct {
 	set      sigSet
 	children []varNode
-	val      interface{}
 }
 
 func (n arrayNode) Infer() (Signature, error) {
@@ -574,7 +573,6 @@ type dictEntry struct {
 type dictNode struct {
 	kset, vset sigSet
 	children   []dictEntry
-	val        interface{}
 }
 
 func (n dictNode) Infer() (Signature, error) {


### PR DESCRIPTION
This enables golangci-lint to be run in GHA CI, and fixes the warnings found.

Lots of changes, although mostly trivial, but require a thorough review. See individual commits for details.

Once merged, more linters can be enabled in addition to the default set.

~~_Currently based on and includes #313 -- will rebase and move out of draft once it's merged._~~