### PR TITLE
auth: handle improperly formatted OK correctly

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -176,9 +176,10 @@ func (conn *Conn) tryAuth(m Auth, state authState, in *bufio.Reader) (error, boo
 					return err, false
 				}
 				state = waitingForReject
+			} else {
+				conn.uuid = string(s[1])
+				return nil, true
 			}
-			conn.uuid = string(s[1])
-			return nil, true
 		case state == waitingForData:
 			err = authWriteLine(conn.transport, []byte("ERROR"))
 			if err != nil {
@@ -191,9 +192,10 @@ func (conn *Conn) tryAuth(m Auth, state authState, in *bufio.Reader) (error, boo
 					return err, false
 				}
 				state = waitingForReject
+			} else {
+				conn.uuid = string(s[1])
+				return nil, true
 			}
-			conn.uuid = string(s[1])
-			return nil, true
 		case state == waitingForOk && string(s[0]) == "DATA":
 			err = authWriteLine(conn.transport, []byte("DATA"))
 			if err != nil {


### PR DESCRIPTION
Propely wait for REJECT after sending the cancel - without this, we
could actually get a panic if the bus sends an OK without a GUID.