### PR TITLE
CI: enable more linters

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -4,3 +4,4 @@ linters:
   enable:
     - gofumpt
     - unconvert
+    - unparam

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -3,3 +3,4 @@
 linters:
   enable:
     - gofumpt
+    - unconvert

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,5 @@
+# For documentation, see https://golangci-lint.run/usage/configuration/
+
+linters:
+  enable:
+    - gofumpt

--- a/_examples/monitor.go
+++ b/_examples/monitor.go
@@ -15,7 +15,7 @@ func main() {
 	}
 	defer conn.Close()
 
-	var rules = []string{
+	rules := []string{
 		"type='signal',member='Notify',path='/org/freedesktop/Notifications',interface='org.freedesktop.Notifications'",
 		"type='method_call',member='Notify',path='/org/freedesktop/Notifications',interface='org.freedesktop.Notifications'",
 		"type='method_return',member='Notify',path='/org/freedesktop/Notifications',interface='org.freedesktop.Notifications'",

--- a/conn.go
+++ b/conn.go
@@ -629,7 +629,7 @@ func (conn *Conn) AddMatchSignal(options ...MatchOption) error {
 
 // AddMatchSignalContext acts like AddMatchSignal but takes a context.
 func (conn *Conn) AddMatchSignalContext(ctx context.Context, options ...MatchOption) error {
-	options = append([]MatchOption{withMatchType("signal")}, options...)
+	options = append([]MatchOption{withMatchTypeSignal()}, options...)
 	return conn.busObj.CallWithContext(
 		ctx,
 		"org.freedesktop.DBus.AddMatch", 0,
@@ -644,7 +644,7 @@ func (conn *Conn) RemoveMatchSignal(options ...MatchOption) error {
 
 // RemoveMatchSignalContext acts like RemoveMatchSignal but takes a context.
 func (conn *Conn) RemoveMatchSignalContext(ctx context.Context, options ...MatchOption) error {
-	options = append([]MatchOption{withMatchType("signal")}, options...)
+	options = append([]MatchOption{withMatchTypeSignal()}, options...)
 	return conn.busObj.CallWithContext(
 		ctx,
 		"org.freedesktop.DBus.RemoveMatch", 0,

--- a/conn.go
+++ b/conn.go
@@ -76,7 +76,6 @@ func SessionBus() (conn *Conn, err error) {
 func getSessionBusAddress(autolaunch bool) (string, error) {
 	if address := os.Getenv("DBUS_SESSION_BUS_ADDRESS"); address != "" && address != "autolaunch:" {
 		return address, nil
-
 	} else if address := tryDiscoverDbusSessionBusAddress(); address != "" {
 		os.Setenv("DBUS_SESSION_BUS_ADDRESS", address)
 		return address, nil
@@ -740,9 +739,7 @@ type transport interface {
 	SendMessage(*Message) error
 }
 
-var (
-	transports = make(map[string]func(string) (transport, error))
-)
+var transports = make(map[string]func(string) (transport, error))
 
 func getTransport(address string) (transport, error) {
 	var err error
@@ -853,16 +850,19 @@ type nameTracker struct {
 func newNameTracker() *nameTracker {
 	return &nameTracker{names: map[string]struct{}{}}
 }
+
 func (tracker *nameTracker) acquireUniqueConnectionName(name string) {
 	tracker.lck.Lock()
 	defer tracker.lck.Unlock()
 	tracker.unique = name
 }
+
 func (tracker *nameTracker) acquireName(name string) {
 	tracker.lck.Lock()
 	defer tracker.lck.Unlock()
 	tracker.names[name] = struct{}{}
 }
+
 func (tracker *nameTracker) loseName(name string) {
 	tracker.lck.Lock()
 	defer tracker.lck.Unlock()
@@ -874,12 +874,14 @@ func (tracker *nameTracker) uniqueNameIsKnown() bool {
 	defer tracker.lck.RUnlock()
 	return tracker.unique != ""
 }
+
 func (tracker *nameTracker) isKnownName(name string) bool {
 	tracker.lck.RLock()
 	defer tracker.lck.RUnlock()
 	_, ok := tracker.names[name]
 	return ok || name == tracker.unique
 }
+
 func (tracker *nameTracker) listKnownNames() []string {
 	tracker.lck.RLock()
 	defer tracker.lck.RUnlock()

--- a/conn_darwin.go
+++ b/conn_darwin.go
@@ -12,7 +12,6 @@ const defaultSystemBusAddress = "unix:path=/opt/local/var/run/dbus/system_bus_so
 func getSessionBusPlatformAddress() (string, error) {
 	cmd := exec.Command("launchctl", "getenv", "DBUS_LAUNCHD_SESSION_BUS_SOCKET")
 	b, err := cmd.CombinedOutput()
-
 	if err != nil {
 		return "", err
 	}

--- a/conn_other.go
+++ b/conn_other.go
@@ -20,7 +20,6 @@ var execCommand = exec.Command
 func getSessionBusPlatformAddress() (string, error) {
 	cmd := execCommand("dbus-launch")
 	b, err := cmd.CombinedOutput()
-
 	if err != nil {
 		return "", err
 	}

--- a/conn_test.go
+++ b/conn_test.go
@@ -279,7 +279,7 @@ func TestAddAndRemoveMatchSignalContext(t *testing.T) {
 	if err = conn.Emit("/", "org.test.CtxTest"); err != nil {
 		t.Fatal(err)
 	}
-	if sig := waitSignal(sigc, "org.test.CtxTest", time.Second); sig == nil {
+	if sig := waitSignal(sigc, "org.test.CtxTest"); sig == nil {
 		t.Fatal("signal receive timed out")
 	}
 
@@ -294,7 +294,7 @@ func TestAddAndRemoveMatchSignalContext(t *testing.T) {
 	if err = conn.Emit("/", "org.test.CtxTest"); err != nil {
 		t.Fatal(err)
 	}
-	if sig := waitSignal(sigc, "org.test.CtxTest", time.Second); sig != nil {
+	if sig := waitSignal(sigc, "org.test.CtxTest"); sig != nil {
 		t.Fatalf("unsubscribed from %q signal, but received %#v", "org.test.CtxTest", sig)
 	}
 }
@@ -319,7 +319,7 @@ func TestAddAndRemoveMatchSignal(t *testing.T) {
 	if err = conn.Emit("/", "org.test.Test"); err != nil {
 		t.Fatal(err)
 	}
-	if sig := waitSignal(sigc, "org.test.Test", time.Second); sig == nil {
+	if sig := waitSignal(sigc, "org.test.Test"); sig == nil {
 		t.Fatal("signal receive timed out")
 	}
 
@@ -333,19 +333,19 @@ func TestAddAndRemoveMatchSignal(t *testing.T) {
 	if err = conn.Emit("/", "org.test.Test"); err != nil {
 		t.Fatal(err)
 	}
-	if sig := waitSignal(sigc, "org.test.Test", time.Second); sig != nil {
+	if sig := waitSignal(sigc, "org.test.Test"); sig != nil {
 		t.Fatalf("unsubscribed from %q signal, but received %#v", "org.test.Test", sig)
 	}
 }
 
-func waitSignal(sigc <-chan *Signal, name string, timeout time.Duration) *Signal {
+func waitSignal(sigc <-chan *Signal, name string) *Signal {
 	for {
 		select {
 		case sig := <-sigc:
 			if sig.Name == name {
 				return sig
 			}
-		case <-time.After(timeout):
+		case <-time.After(time.Second):
 			return nil
 		}
 	}

--- a/dbus.go
+++ b/dbus.go
@@ -82,7 +82,7 @@ func storeBase(dest, src reflect.Value) error {
 
 func setDest(dest, src reflect.Value) error {
 	if !isVariant(src.Type()) && isVariant(dest.Type()) {
-		//special conversion for dbus.Variant
+		// special conversion for dbus.Variant
 		dest.Set(reflect.ValueOf(MakeVariant(src.Interface())))
 		return nil
 	}
@@ -163,8 +163,8 @@ func storeMapIntoVariant(dest, src reflect.Value) error {
 func storeMapIntoInterface(dest, src reflect.Value) error {
 	var dv reflect.Value
 	if isVariant(src.Type().Elem()) {
-		//Convert variants to interface{} recursively when converting
-		//to interface{}
+		// Convert variants to interface{} recursively when converting
+		// to interface{}
 		dv = reflect.MakeMap(
 			reflect.MapOf(src.Type().Key(), interfaceType))
 	} else {
@@ -197,7 +197,7 @@ func storeMapIntoMap(dest, src reflect.Value) error {
 func storeSlice(dest, src reflect.Value) error {
 	switch {
 	case src.Type() == interfacesType && dest.Kind() == reflect.Struct:
-		//The decoder always decodes structs as slices of interface{}
+		// The decoder always decodes structs as slices of interface{}
 		return storeStruct(dest, src)
 	case !kindsAreCompatible(dest.Type(), src.Type()):
 		return fmt.Errorf(
@@ -257,8 +257,8 @@ func storeSliceIntoVariant(dest, src reflect.Value) error {
 func storeSliceIntoInterface(dest, src reflect.Value) error {
 	var dv reflect.Value
 	if isVariant(src.Type().Elem()) {
-		//Convert variants to interface{} recursively when converting
-		//to interface{}
+		// Convert variants to interface{} recursively when converting
+		// to interface{}
 		dv = reflect.MakeSlice(reflect.SliceOf(interfaceType),
 			src.Len(), src.Cap())
 	} else {

--- a/decoder.go
+++ b/decoder.go
@@ -205,9 +205,9 @@ func (dec *decoder) decode(s string, depth int) interface{} {
 		// Even for empty arrays, the correct padding must be included
 		align := alignment(typeFor(s[1:]))
 		if len(s) > 1 && s[1] == '(' {
-			//Special case for arrays of structs
-			//structs decode as a slice of interface{} values
-			//but the dbus alignment does not match this
+			// Special case for arrays of structs
+			// structs decode as a slice of interface{} values
+			// but the dbus alignment does not match this
 			align = 8
 		}
 		dec.align(align)

--- a/default_handler.go
+++ b/default_handler.go
@@ -148,7 +148,7 @@ func (m exportedMethod) Call(args ...interface{}) ([]interface{}, error) {
 		out[i] = val.Interface()
 	}
 	if nilErr || err == nil {
-		//concrete type to interface nil is a special case
+		// concrete type to interface nil is a special case
 		return out, nil
 	}
 	return out, err

--- a/exec_command_test.go
+++ b/exec_command_test.go
@@ -10,17 +10,21 @@ import (
 // How to mock exec.Command for unit tests
 // https://stackoverflow.com/q/45789101/10513533
 
-var mockedExitStatus = 0
-var mockedStdout string
+var (
+	mockedExitStatus = 0
+	mockedStdout     string
+)
 
 func fakeExecCommand(command string, args ...string) *exec.Cmd {
 	cs := []string{"-test.run=TestExecCommandHelper", "--", command}
 	cs = append(cs, args...)
 	cmd := exec.Command(os.Args[0], cs...)
 	es := strconv.Itoa(mockedExitStatus)
-	cmd.Env = []string{"GO_WANT_HELPER_PROCESS=1",
+	cmd.Env = []string{
+		"GO_WANT_HELPER_PROCESS=1",
 		"STDOUT=" + mockedStdout,
-		"EXIT_STATUS=" + es}
+		"EXIT_STATUS=" + es,
+	}
 	return cmd
 }
 

--- a/match.go
+++ b/match.go
@@ -26,10 +26,10 @@ func WithMatchOption(key, value string) MatchOption {
 	return MatchOption{key, value}
 }
 
-// doesn't make sense to export this option because clients can only
-// subscribe to messages with signal type.
-func withMatchType(typ string) MatchOption {
-	return WithMatchOption("type", typ)
+// It does not make sense to have a public WithMatchType function
+// because clients can only subscribe to messages with signal type.
+func withMatchTypeSignal() MatchOption {
+	return WithMatchOption("type", "signal")
 }
 
 // WithMatchSender sets sender match option.

--- a/match_test.go
+++ b/match_test.go
@@ -4,7 +4,7 @@ import "testing"
 
 func TestFormatMatchOptions(t *testing.T) {
 	opts := []MatchOption{
-		withMatchType("signal"),
+		withMatchTypeSignal(),
 		WithMatchSender("org.bluez"),
 		WithMatchInterface("org.freedesktop.DBus.Properties"),
 		WithMatchMember("PropertiesChanged"),

--- a/message_test.go
+++ b/message_test.go
@@ -3,7 +3,7 @@ package dbus
 import "testing"
 
 func TestMessage_validateHeader(t *testing.T) {
-	var tcs = []struct {
+	tcs := []struct {
 		msg Message
 		err error
 	}{
@@ -85,7 +85,6 @@ func TestMessage_validateHeader(t *testing.T) {
 			err: InvalidMessageError("invalid error name"),
 		},
 		{
-
 			msg: Message{
 				Type: TypeError,
 				Headers: map[HeaderField]Variant{

--- a/object.go
+++ b/object.go
@@ -46,7 +46,7 @@ func (o *Object) CallWithContext(ctx context.Context, method string, flags Flags
 // Deprecated: use (*Conn) AddMatchSignal instead.
 func (o *Object) AddMatchSignal(iface, member string, options ...MatchOption) *Call {
 	base := []MatchOption{
-		withMatchType("signal"),
+		withMatchTypeSignal(),
 		WithMatchInterface(iface),
 		WithMatchMember(member),
 	}
@@ -65,7 +65,7 @@ func (o *Object) AddMatchSignal(iface, member string, options ...MatchOption) *C
 // Deprecated: use (*Conn) RemoveMatchSignal instead.
 func (o *Object) RemoveMatchSignal(iface, member string, options ...MatchOption) *Call {
 	base := []MatchOption{
-		withMatchType("signal"),
+		withMatchTypeSignal(),
 		WithMatchInterface(iface),
 		WithMatchMember(member),
 	}

--- a/prop/prop.go
+++ b/prop/prop.go
@@ -148,7 +148,7 @@ type Prop struct {
 // Introspection returns the introspection data for p.
 // The "name" argument is used as the property's name in the resulting data.
 func (p *Prop) Introspection(name string) introspect.Property {
-	var result = introspect.Property{Name: name, Type: dbus.SignatureOf(p.Value).String()}
+	result := introspect.Property{Name: name, Type: dbus.SignatureOf(p.Value).String()}
 	if p.Writable {
 		result.Access = "readwrite"
 	} else {

--- a/store_test.go
+++ b/store_test.go
@@ -77,7 +77,8 @@ func TestStoreSliceVariantToSliceInterfaceMulti(t *testing.T) {
 
 func TestStoreNested(t *testing.T) {
 	src := map[string]interface{}{
-		"foo": []interface{}{"1", "2", "3", "5",
+		"foo": []interface{}{
+			"1", "2", "3", "5",
 			map[string]interface{}{
 				"bar": "baz",
 			},

--- a/variant_test.go
+++ b/variant_test.go
@@ -1,7 +1,9 @@
 package dbus
 
-import "reflect"
-import "testing"
+import (
+	"reflect"
+	"testing"
+)
 
 var variantFormatTests = []struct {
 	v interface{}
@@ -54,8 +56,10 @@ var variantParseTests = []struct {
 	{`@a{ss} {}`, map[string]string{}},
 	{`{"foo": 1}`, map[string]int32{"foo": 1}},
 	{`[{}, {"foo": "bar"}]`, []map[string]string{{}, {"foo": "bar"}}},
-	{`{"a": <1>, "b": <"foo">}`,
-		map[string]Variant{"a": MakeVariant(int32(1)), "b": MakeVariant("foo")}},
+	{
+		`{"a": <1>, "b": <"foo">}`,
+		map[string]Variant{"a": MakeVariant(int32(1)), "b": MakeVariant("foo")},
+	},
 	{`b''`, []byte{0}},
 	{`b"abc"`, []byte{'a', 'b', 'c', 0}},
 	{`b"\x01\0002\a\b\f\n\r\t"`, []byte{1, 2, 0x7, 0x8, 0xc, '\n', '\r', '\t', 0}},
@@ -88,5 +92,4 @@ func TestVariantStore(t *testing.T) {
 	if result != str {
 		t.Fatalf("expected %s, got %s\n", str, result)
 	}
-
 }


### PR DESCRIPTION
This PR enables a few more linters, and fixes warnings found by those. See individual commits for details.

The next linter to add would be `errorlint`, but the amount of changes requires is a tad too big to include it into this PR.