### PR TITLE
Protect object map from concurrent access

### DIFF
--- a/default_handler.go
+++ b/default_handler.go
@@ -38,12 +38,16 @@ type defaultHandler struct {
 	defaultIntf map[string]*exportedIntf
 }
 
-func (h *defaultHandler) PathExists(path ObjectPath) bool {
-	_, ok := h.objects[path]
-	return ok
+func (h *defaultHandler) PathExists(path ObjectPath) (*exportedObj, bool) {
+	h.RLock()
+	defer h.RUnlock()
+	obj, ok := h.objects[path]
+	return obj, ok
 }
 
 func (h *defaultHandler) introspectPath(path ObjectPath) string {
+	h.RLock()
+	defer h.RUnlock()
 	subpath := make(map[string]struct{})
 	var xml bytes.Buffer
 	xml.WriteString("<node>")


### PR DESCRIPTION
In situations with many concurrent dbus requests and at the same time new objects are registered it is possible to end up in a situation where the object map is write and read accessed from different go routines resulting in a panic.

The patch is working in our setup but I've not run any test other than 'go test'