### PR TITLE
Reduce allocs in decode function

### DIFF
--- a/decoder.go
+++ b/decoder.go
@@ -11,6 +11,17 @@ type decoder struct {
 	order binary.ByteOrder
 	pos   int
 	fds   []int
+
+	// The following fields are used to reduce memory allocs.
+	buf []byte
+	d   float64
+	t   uint64
+	x   int64
+	u   uint32
+	i   int32
+	n   int16
+	q   uint16
+	y   [1]byte
 }
 
 // newDecoder returns a new decoder that reads values from in. The input is
@@ -27,8 +38,7 @@ func newDecoder(in io.Reader, order binary.ByteOrder, fds []int) *decoder {
 func (dec *decoder) align(n int) {
 	if dec.pos%n != 0 {
 		newpos := (dec.pos + n - 1) & ^(n - 1)
-		empty := make([]byte, newpos-dec.pos)
-		if _, err := io.ReadFull(dec.in, empty); err != nil {
+		if err := dec.read2buf(newpos - dec.pos); err != nil {
 			panic(err)
 		}
 		dec.pos = newpos
@@ -66,79 +76,91 @@ func (dec *decoder) Decode(sig Signature) (vs []interface{}, err error) {
 	return vs, nil
 }
 
+// read2buf reads exactly n bytes from the reader dec.in into the buffer dec.buf
+// to reduce memory allocs.
+// The buffer grows automatically.
+func (dec *decoder) read2buf(n int) error {
+	if cap(dec.buf) < n {
+		dec.buf = make([]byte, n)
+	} else {
+		dec.buf = dec.buf[:n]
+	}
+	_, err := io.ReadFull(dec.in, dec.buf)
+	return err
+}
+
+// decodeU decodes uint32 obtained from the reader dec.in.
+// The goal is to reduce memory allocs.
+func (dec *decoder) decodeU() uint32 {
+	dec.binread(&dec.u)
+	dec.pos += 4
+	return dec.u
+}
+
 func (dec *decoder) decode(s string, depth int) interface{} {
 	dec.align(alignment(typeFor(s)))
 	switch s[0] {
 	case 'y':
-		var b [1]byte
-		if _, err := dec.in.Read(b[:]); err != nil {
+		if _, err := dec.in.Read(dec.y[:]); err != nil {
 			panic(err)
 		}
 		dec.pos++
-		return b[0]
+		return dec.y[0]
 	case 'b':
-		i := dec.decode("u", depth).(uint32)
-		switch {
-		case i == 0:
+		switch dec.decodeU() {
+		case 0:
 			return false
-		case i == 1:
+		case 1:
 			return true
 		default:
 			panic(FormatError("invalid value for boolean"))
 		}
 	case 'n':
-		var i int16
-		dec.binread(&i)
+		dec.binread(&dec.n)
 		dec.pos += 2
-		return i
+		return dec.n
 	case 'i':
-		var i int32
-		dec.binread(&i)
+		dec.binread(&dec.i)
 		dec.pos += 4
-		return i
+		return dec.i
 	case 'x':
-		var i int64
-		dec.binread(&i)
+		dec.binread(&dec.x)
 		dec.pos += 8
-		return i
+		return dec.x
 	case 'q':
-		var i uint16
-		dec.binread(&i)
+		dec.binread(&dec.q)
 		dec.pos += 2
-		return i
+		return dec.q
 	case 'u':
-		var i uint32
-		dec.binread(&i)
-		dec.pos += 4
-		return i
+		return dec.decodeU()
 	case 't':
-		var i uint64
-		dec.binread(&i)
+		dec.binread(&dec.t)
 		dec.pos += 8
-		return i
+		return dec.t
 	case 'd':
-		var f float64
-		dec.binread(&f)
+		dec.binread(&dec.d)
 		dec.pos += 8
-		return f
+		return dec.d
 	case 's':
-		length := dec.decode("u", depth).(uint32)
-		b := make([]byte, int(length)+1)
-		if _, err := io.ReadFull(dec.in, b); err != nil {
+		length := dec.decodeU()
+		p := int(length) + 1
+		if err := dec.read2buf(p); err != nil {
 			panic(err)
 		}
-		dec.pos += int(length) + 1
-		return string(b[:len(b)-1])
+		dec.pos += p
+		return string(dec.buf[:len(dec.buf)-1])
 	case 'o':
 		return ObjectPath(dec.decode("s", depth).(string))
 	case 'g':
 		length := dec.decode("y", depth).(byte)
-		b := make([]byte, int(length)+1)
-		if _, err := io.ReadFull(dec.in, b); err != nil {
+		p := int(length) + 1
+		if err := dec.read2buf(p); err != nil {
 			panic(err)
 		}
-		dec.pos += int(length) + 1
-		sig, err := ParseSignature(string(b[:len(b)-1]))
+		dec.pos += p
+		sig, err := ParseSignature(
+			string(dec.buf[:len(dec.buf)-1]),
+		)
 		if err != nil {
 			panic(err)
 		}
@@ -163,7 +185,7 @@ func (dec *decoder) decode(s string, depth int) interface{} {
 		variant.value = dec.decode(sig.str, depth+1)
 		return variant
 	case 'h':
-		idx := dec.decode("u", depth).(uint32)
+		idx := dec.decodeU()
 		if int(idx) < len(dec.fds) {
 			return UnixFD(dec.fds[idx])
 		}
@@ -176,7 +198,7 @@ func (dec *decoder) decode(s string, depth int) interface{} {
 			if depth >= 63 {
 				panic(FormatError("input exceeds container depth limit"))
 			}
-			length := dec.decode("u", depth).(uint32)
+			length := dec.decodeU()
 			// Even for empty maps, the correct padding must be included
 			dec.align(8)
 			spos := dec.pos
@@ -195,7 +217,7 @@ func (dec *decoder) decode(s string, depth int) interface{} {
 			panic(FormatError("input exceeds container depth limit"))
 		}
 		sig := s[1:]
-		length := dec.decode("u", depth).(uint32)
+		length := dec.decodeU()
 		// capacity can be determined only for fixed-size element types
 		var capacity int
 		if s := sigByteSize(sig); s != 0 {

--- a/encoder_test.go
+++ b/encoder_test.go
@@ -171,6 +171,31 @@ func TestEncodeSliceInterface(t *testing.T) {
 	}
 }
 
+func BenchmarkEncodeSliceInterface(b *testing.B) {
+	val := []interface{}{"foo", "bar"}
+	sig := SignatureOf(val)
+	buf := &bytes.Buffer{}
+	fds := make([]int, 0)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		buf.Reset()
+
+		enc := newEncoder(buf, binary.LittleEndian, fds)
+		err := enc.Encode(val)
+		if err != nil {
+			b.Fatal(err)
+		}
+
+		dec := newDecoder(buf, binary.LittleEndian, enc.fds)
+		_, err = dec.Decode(sig)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
 func TestEncodeSliceNamedInterface(t *testing.T) {
 	val := []empty{"foo", "bar"}
 	buf := new(bytes.Buffer)


### PR DESCRIPTION
Hi! I tried to reduce memory allocations in the decode function to reduce GC pressure.

```
# new
BenchmarkEncodeSliceInterface-2   	  457238	      2609 ns/op	     732 B/op	      38 allocs/op
# old
BenchmarkEncodeSliceInterface-2   	  434961	      2706 ns/op	     628 B/op	      46 allocs/op
```

Apologies if I broke certain dbus protocol assumptions during refactoring, I am not very familiar with the codebase.