### PR TITLE
Fix missing alignment in decodeU()

### DIFF
--- a/decoder.go
+++ b/decoder.go
@@ -100,6 +100,7 @@ func (dec *decoder) read2buf(n int) error {
 // decodeU decodes uint32 obtained from the reader dec.in.
 // The goal is to reduce memory allocs.
 func (dec *decoder) decodeU() uint32 {
+	dec.align(4)
 	dec.binread(&dec.u)
 	dec.pos += 4
 	return dec.u


### PR DESCRIPTION
During refactoring in #344, the newly added decodeU() function skips the dec.align() call from the original decode("u") routine. This unfortunately breaks parsing of boolean values with a lot of the following errors:

```
dbus: wire format error: invalid value for boolean
```

Adding a fixed align() call here fixes the problem.