### PR TITLE
Pointer semantics in depthCounter

### DIFF
--- a/sig.go
+++ b/sig.go
@@ -183,19 +183,19 @@ func (cnt *depthCounter) Valid() bool {
 	return cnt.arrayDepth <= 32 && cnt.structDepth <= 32 && cnt.dictEntryDepth <= 32
 }
 
-func (cnt depthCounter) EnterArray() *depthCounter {
+func (cnt *depthCounter) EnterArray() *depthCounter {
 	cnt.arrayDepth++
-	return &cnt
+	return cnt
 }
 
-func (cnt depthCounter) EnterStruct() *depthCounter {
+func (cnt *depthCounter) EnterStruct() *depthCounter {
 	cnt.structDepth++
-	return &cnt
+	return cnt
 }
 
-func (cnt depthCounter) EnterDictEntry() *depthCounter {
+func (cnt *depthCounter) EnterDictEntry() *depthCounter {
 	cnt.dictEntryDepth++
-	return &cnt
+	return cnt
 }
 
 // Try to read a single type from this string. If it was successful, err is nil


### PR DESCRIPTION
Hi! I noticed that there is an inconsistent usage of pointer and value semantics in the `depthCounter` struct. In case both options achieve the same goal, it would be beneficial to stick to one (e.g., to the pointer semantics) to reduce allocs, i.e., 42 less allocs per operation, and almost 1KB of memory saved per operation.

```sh
$ go test -run='^$' -benchmem -bench '^BenchmarkUnixFDs$'
...
# new
BenchmarkUnixFDs-2   	    6584	    221914 ns/op	   15276 B/op	     563 allocs/op
# old
BenchmarkUnixFDs-2   	    4662	    307360 ns/op	   16290 B/op	     605 allocs/op

$ benchstat bench-old.txt bench-pointer.txt
name       old time/op    new time/op    delta
UnixFDs-2     263µs ±29%     273µs ±26%    ~     (p=0.720 n=9+10)

name       old alloc/op   new alloc/op   delta
UnixFDs-2    16.3kB ± 0%    15.3kB ± 0%  -6.19%  (p=0.000 n=8+6)

name       old allocs/op  new allocs/op  delta
UnixFDs-2       605 ± 0%       563 ± 0%  -6.94%  (p=0.000 n=10+10)
```