### PR TITLE
Do not encode message to check its validity after decoding

### DIFF
--- a/transport_unix.go
+++ b/transport_unix.go
@@ -200,7 +200,7 @@ func (t *unixTransport) ReadMessage() (*Message, error) {
 			return nil, err
 		}
 		dec.Reset(r, order, fds)
-		if err = decodeMessageBody(msg, dec, b); err != nil {
+		if err = decodeMessageBody(msg, dec); err != nil {
 			return nil, err
 		}
 		// substitute the values in the message body (which are indices for the
@@ -227,25 +227,19 @@ func (t *unixTransport) ReadMessage() (*Message, error) {
 	}
 
 	dec.Reset(r, order, nil)
-	if err = decodeMessageBody(msg, dec, b); err != nil {
+	if err = decodeMessageBody(msg, dec); err != nil {
 		return nil, err
 	}
 	return msg, nil
 }
 
-func decodeMessageBody(msg *Message, dec *decoder, b *bytes.Buffer) error {
-	// Check whether message is valid.
-	b.Reset()
-	err := msg.EncodeTo(b, nativeEndian)
-	if err != nil {
-		return err
-	}
-
+func decodeMessageBody(msg *Message, dec *decoder) error {
 	sig, _ := msg.Headers[FieldSignature].value.(Signature)
 	if sig.str == "" {
 		return nil
 	}
 
+	var err error
 	msg.Body, err = dec.Decode(sig)
 	return err
 }


### PR DESCRIPTION
Hi! I am not 100% sure, but encoding a message with `msg.EncodeTo` to check whether the message is valid right after it was decoded looks redundant and it incurs 2.9kB and 140 allocs per operation. If the message was corrupted, it would have failed earlier at the decoding stage in `unixTransport.ReadMessage`.

```sh
$ go test -run='^$' -benchmem -bench '^BenchmarkUnixFDs$'
# new
BenchmarkUnixFDs-2   	    8366	    279509 ns/op	   13437 B/op	     465 allocs/op
# old
BenchmarkUnixFDs-2   	    7744	    329736 ns/op	   16275 B/op	     605 allocs/op

$ benchstat bench-old.txt bench-noenc.txt
name       old time/op    new time/op    delta
UnixFDs-2     311µs ±49%     250µs ±30%     ~     (p=0.105 n=10+10)

name       old alloc/op   new alloc/op   delta
UnixFDs-2    16.3kB ± 0%    13.4kB ± 0%  -17.44%  (p=0.000 n=9+9)

name       old allocs/op  new allocs/op  delta
UnixFDs-2       605 ± 0%       465 ± 0%  -23.14%  (p=0.000 n=10+10)
```