### PR TITLE
Fix compilation on FreeBSD

### DIFF
--- a/transport_unixcred_freebsd.go
+++ b/transport_unixcred_freebsd.go
@@ -41,7 +41,7 @@ const (
 
 // http://golang.org/src/pkg/syscall/sockcmsg_unix.go
 func cmsgAlignOf(salen int) int {
-	salign := unix.SizeofPtr
+	salign := int(unix.SizeofPtr)
 
 	return (salen + salign - 1) & ^(salign - 1)
 }


### PR DESCRIPTION
This code was copied from the syscall package in Go but it does not seem to be working as salign is of type `_Ctype_int` and salen is an `int` (strange). This fixes the compile error of mismatched types by converting to int.