### PR TITLE
Only check header validity when decoding messages

### DIFF
--- a/message.go
+++ b/message.go
@@ -188,7 +188,7 @@ func DecodeMessageWithFDs(rd io.Reader, fds []int) (msg *Message, err error) {
 		}
 	}
 
-	if err = msg.IsValid(); err != nil {
+	if err = msg.validateHeader(); err != nil {
 		return nil, err
 	}
 	sig, _ := msg.Headers[FieldSignature].value.(Signature)

--- a/transport_unix.go
+++ b/transport_unix.go
@@ -200,7 +200,7 @@ func (t *unixTransport) ReadMessage() (*Message, error) {
 			return nil, err
 		}
 		dec.Reset(r, order, fds)
-		if err = decodeMessageBody(msg, dec, b); err != nil {
+		if err = decodeMessageBody(msg, dec); err != nil {
 			return nil, err
 		}
 		// substitute the values in the message body (which are indices for the
@@ -227,25 +227,19 @@ func (t *unixTransport) ReadMessage() (*Message, error) {
 	}
 
 	dec.Reset(r, order, nil)
-	if err = decodeMessageBody(msg, dec, b); err != nil {
+	if err = decodeMessageBody(msg, dec); err != nil {
 		return nil, err
 	}
 	return msg, nil
 }
 
-func decodeMessageBody(msg *Message, dec *decoder, b *bytes.Buffer) error {
-	// Check whether message is valid.
-	b.Reset()
-	err := msg.EncodeTo(b, nativeEndian)
-	if err != nil {
-		return err
-	}
-
+func decodeMessageBody(msg *Message, dec *decoder) error {
 	sig, _ := msg.Headers[FieldSignature].value.(Signature)
 	if sig.str == "" {
 		return nil
 	}
 
+	var err error
 	msg.Body, err = dec.Decode(sig)
 	return err
 }

--- a/transport_unix.go
+++ b/transport_unix.go
@@ -234,6 +234,10 @@ func (t *unixTransport) ReadMessage() (*Message, error) {
 }
 
 func decodeMessageBody(msg *Message, dec *decoder) error {
+	if err := msg.validateHeader(); err != nil {
+		return err
+	}
+
 	sig, _ := msg.Headers[FieldSignature].value.(Signature)
 	if sig.str == "" {
 		return nil


### PR DESCRIPTION
Don't just do a full encode again. Includes https://github.com/godbus/dbus/pull/353.