### PR TITLE
Replaced godoc url with pkg.go.dev url for v5.

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ go get github.com/godbus/dbus/v5
 ### Usage
 
 The complete package documentation and some simple examples are available at
-[godoc.org](http://godoc.org/github.com/godbus/dbus). Also, the
+[pkg.go.dev](https://pkg.go.dev/github.com/godbus/dbus/v5). Also, the
 [_examples](https://github.com/godbus/dbus/tree/master/_examples) directory
 gives a short overview over the basic usage. 
 


### PR DESCRIPTION
The old godoc.org url directed to an outdated v4 page. This PR updates the link to use the current v5 version of the documentation, found at pkg.go.dev. As godoc.org redirects to pkg.go.dev, it appears that godoc.org is deprecated.