### PR TITLE
Add ConnOption WithDefaultSendTimeout

### DIFF
--- a/object.go
+++ b/object.go
@@ -31,12 +31,12 @@ type Object struct {
 
 // Call calls a method with (*Object).Go and waits for its reply.
 func (o *Object) Call(method string, flags Flags, args ...interface{}) *Call {
-	return <-o.createCall(context.Background(), method, flags, make(chan *Call, 1), false, args...).Done
+	return <-o.createCall(context.TODO(), method, flags, make(chan *Call, 1), args...).Done
 }
 
 // CallWithContext acts like Call but takes a context
 func (o *Object) CallWithContext(ctx context.Context, method string, flags Flags, args ...interface{}) *Call {
-	return <-o.createCall(ctx, method, flags, make(chan *Call, 1), true, args...).Done
+	return <-o.createCall(ctx, method, flags, make(chan *Call, 1), args...).Done
 }
 
 // AddMatchSignal subscribes BusObject to signals from specified interface,
@@ -90,15 +90,15 @@ func (o *Object) RemoveMatchSignal(iface, member string, options ...MatchOption)
 // If the method parameter contains a dot ('.'), the part before the last dot
 // specifies the interface on which the method is called.
 func (o *Object) Go(method string, flags Flags, ch chan *Call, args ...interface{}) *Call {
-	return o.createCall(context.Background(), method, flags, ch, false, args...)
+	return o.createCall(context.TODO(), method, flags, ch, args...)
 }
 
 // GoWithContext acts like Go but takes a context
 func (o *Object) GoWithContext(ctx context.Context, method string, flags Flags, ch chan *Call, args ...interface{}) *Call {
-	return o.createCall(ctx, method, flags, ch, true, args...)
+	return o.createCall(ctx, method, flags, ch, args...)
 }
 
-func (o *Object) createCall(ctx context.Context, method string, flags Flags, ch chan *Call, withContext bool, args ...interface{}) *Call {
+func (o *Object) createCall(ctx context.Context, method string, flags Flags, ch chan *Call, args ...interface{}) *Call {
 	if ctx == nil {
 		panic("nil context")
 	}
@@ -122,10 +122,7 @@ func (o *Object) createCall(ctx context.Context, method string, flags Flags, ch 
 	if len(args) > 0 {
 		msg.Headers[FieldSignature] = MakeVariant(SignatureOf(args...))
 	}
-	if withContext {
-		return o.conn.SendWithContext(ctx, msg, ch)
-	}
-	return o.conn.Send(msg, ch)
+	return o.conn.SendWithContext(ctx, msg, ch)
 }
 
 // GetProperty calls org.freedesktop.DBus.Properties.Get on the given


### PR DESCRIPTION
Added a default timeout for a connection, as well as a ConnOption to
set this value. If a default timeout has been set, all calls from that
connection will be aborted if the timeout is exceeded. If the context is 
specified in the call, we ignore the default timeout.

If we always want to have the same timeout for all calls from a connection,
it would be easier if the timeout could be set once to the
connection itself rather than always having to use CallWithContext. 