### PR TITLE
Use the default fallback path for the session bus

### DIFF
--- a/conn_other.go
+++ b/conn_other.go
@@ -4,7 +4,6 @@
 package dbus
 
 import (
-	"bytes"
 	"errors"
 	"fmt"
 	"io/ioutil"
@@ -18,23 +17,12 @@ import (
 var execCommand = exec.Command
 
 func getSessionBusPlatformAddress() (string, error) {
-	cmd := execCommand("dbus-launch")
-	b, err := cmd.CombinedOutput()
-	if err != nil {
-		return "", err
-	}
-
-	i := bytes.IndexByte(b, '=')
-	j := bytes.IndexByte(b, '\n')
-
-	if i == -1 || j == -1 || i > j {
+	rundir, ok := os.LookupEnv("XDG_RUNTIME_DIR")
+	if !ok {
 		return "", errors.New("dbus: couldn't determine address of session bus")
 	}
 
-	env, addr := string(b[0:i]), string(b[i+1:j])
-	os.Setenv(env, addr)
-
-	return addr, nil
+	return path.Join(rundir, "bus"), nil
 }
 
 // tryDiscoverDbusSessionBusAddress tries to discover an existing dbus session


### PR DESCRIPTION
This is currently a de-facto standard done by most libraries, and is being amended into the spec itself[1].

The previous behaviour (starting a new D-Bus server via dbus-launch) is generally discouraged, since it will start a D-Bus at a non-standard location and other processes have no mechanism via which they can locate the bus socket.

[1]: https://gitlab.freedesktop.org/dbus/dbus/-/merge_requests/395

Fixes: https://github.com/godbus/dbus/issues/372