### PR TITLE
introspect: add Peer to introspection

### DIFF
--- a/introspect/introspect.go
+++ b/introspect/introspect.go
@@ -17,6 +17,22 @@ var IntrospectData = Interface{
 	},
 }
 
+// PeerData is the introspection data for the org.freedesktop.DBus.Peer interface.
+var PeerData = Interface{
+	Name: "org.freedesktop.DBus.Peer",
+	Methods: []Method{
+		{
+			Name: "Ping",
+		},
+		{
+			Name: "GetMachineId",
+			Args: []Arg{
+				{"machine_uuid", "s", "out"},
+			},
+		},
+	},
+}
+
 // XML document type declaration of the introspection format version 1.0
 const IntrospectDeclarationString = `
 	<!DOCTYPE node PUBLIC "-//freedesktop//DTD D-BUS Object Introspection 1.0//EN"

--- a/introspect/introspectable.go
+++ b/introspect/introspectable.go
@@ -16,19 +16,35 @@ import (
 type Introspectable string
 
 // NewIntrospectable returns an Introspectable that returns the introspection
-// data that corresponds to the given Node. If n.Interfaces doesn't contain the
-// data for org.freedesktop.DBus.Introspectable, it is added automatically.
+// data that corresponds to the given Node.
+//
+// If n.Interfaces doesn't contain the data for
+// org.freedesktop.DBus.Introspectable or org.freedesktop.DBus.Peer, they are
+// added automatically.
 func NewIntrospectable(n *Node) Introspectable {
-	found := false
+	foundIntrospect := false
+	foundPeer := false
+
 	for _, v := range n.Interfaces {
 		if v.Name == "org.freedesktop.DBus.Introspectable" {
-			found = true
+			foundIntrospect = true
+			break
+		}
+
+		if v.Name == "org.freedesktop.DBus.Peer" {
+			foundPeer = true
 			break
 		}
 	}
-	if !found {
+
+	if !foundIntrospect {
 		n.Interfaces = append(n.Interfaces, IntrospectData)
 	}
+
+	if !foundPeer {
+		n.Interfaces = append(n.Interfaces, PeerData)
+	}
+
 	b, err := xml.Marshal(n)
 	if err != nil {
 		panic(err)


### PR DESCRIPTION
without this, there's no Peer interface in the introspection data, even though the interface is already internally handled by this package.