### PR TITLE
export struct members for signature benchmark

### DIFF
--- a/sig_test.go
+++ b/sig_test.go
@@ -49,10 +49,10 @@ func TestSig(t *testing.T) {
 
 var getSigTest = []interface{}{
 	[]struct {
-		b byte
-		i int32
-		t uint64
-		s string
+		B byte
+		I int32
+		T uint64
+		S string
 	}{},
 	map[string]Variant{},
 }


### PR DESCRIPTION
i assume unexported fields are skipped on purpose, but computing the signature of a struct with no exported fields in a benchmark seems sort of pointless and also panics. export the fields so that we actually compute their signature, and prevent panic'ing on an empty struct.

fixes:

	panic: dbus: invalid type struct { b uint8; i int32; t uint64; s string }

	goroutine 12 [running]:
	github.com/godbus/dbus/v5.getSignature({0x74c3c0, 0x6bbf60}, 0xc0000aaed8)
		/home/mischief/src/go-dbus/sig.go:106 +0xa25
	github.com/godbus/dbus/v5.getSignature({0x74c3c0, 0x6822e0}, 0xc0000aaed8)
		/home/mischief/src/go-dbus/sig.go:110 +0x60c
	github.com/godbus/dbus/v5.SignatureOf({0x8fcb40?, 0xc000193f40?, 0x518452?})
		/home/mischief/src/go-dbus/sig.go:37 +0x50
	github.com/godbus/dbus/v5.BenchmarkGetSignatureLong(0xc000148788)
		/home/mischief/src/go-dbus/sig_test.go:68 +0x36
	testing.(*B).runN(0xc000148788, 0x1)
		/usr/lib/go/src/testing/benchmark.go:193 +0xf8
	testing.(*B).run1.func1()
		/usr/lib/go/src/testing/benchmark.go:215 +0x4e
	created by testing.(*B).run1 in goroutine 1
		/usr/lib/go/src/testing/benchmark.go:208 +0x90

when executing:

	go test -v -bench BenchmarkGetSignatureLong -run ^$ .