### PR TITLE
Bump CI versions

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,10 +1,10 @@
 freebsd_instance:
-  image_family: freebsd-13-0
+  image_family: freebsd-14-0
 
 task:
   name: Test on FreeBSD
-  install_script: pkg install -y go119 dbus
+  install_script: pkg install -y go122 dbus
   test_script: |
     /usr/local/etc/rc.d/dbus onestart && \
     eval `dbus-launch --sh-syntax` && \
-    go119 test -v ./...
+    go122 test -v ./...

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,22 +12,22 @@ permissions:
 jobs:
 
   lint:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
-          go-version: 1.19
+          go-version: 1.23
       - uses: golangci/golangci-lint-action@v3
         with:
           version: v1.50
 
   test:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:
-        go-version: ['1.16', '1.17', '1.18', '1.19', '1.20']
+        go-version: ['1.22', '1.23']
 
     steps:
 
@@ -49,7 +49,7 @@ jobs:
       run: go test -race -v ./...
 
   codespell:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v3
     - uses: codespell-project/actions-codespell@master

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,16 +18,16 @@ jobs:
       - uses: actions/setup-go@v3
         with:
           go-version: 1.23
-      - uses: golangci/golangci-lint-action@v3
+      - uses: golangci/golangci-lint-action@v6
         with:
-          version: v1.50
+          version: v1.60
 
   test:
     runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:
-        go-version: ['1.22', '1.23']
+        go-version: ['1.20', '1.21', '1.22', '1.23']
 
     steps:
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ D-Bus message bus system.
 
 ### Installation
 
-This packages requires Go 1.12 or later. It can be installed by running the command below:
+This packages requires Go 1.20 or later. It can be installed by running the command below:
 
 ```
 go get github.com/godbus/dbus/v5

--- a/conn_linux_test.go
+++ b/conn_linux_test.go
@@ -2,7 +2,6 @@ package dbus
 
 import (
 	"bufio"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"syscall"
@@ -46,7 +45,7 @@ func startDaemonInDifferentUserNamespace(t *testing.T) (string, *os.Process) {
 	</policy>   
    </busconfig>
    `
-	cfg, err := ioutil.TempFile("", "")
+	cfg, err := os.CreateTemp("", "")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/conn_other.go
+++ b/conn_other.go
@@ -7,7 +7,6 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"os/user"
@@ -61,7 +60,7 @@ func tryDiscoverDbusSessionBusAddress() string {
 			// text file // containing the address of the socket, e.g.:
 			// DBUS_SESSION_BUS_ADDRESS=unix:abstract=/tmp/dbus-E1c73yNqrG
 
-			if f, err := ioutil.ReadFile(runUserSessionDbusFile); err == nil {
+			if f, err := os.ReadFile(runUserSessionDbusFile); err == nil {
 				fileContent := string(f)
 
 				prefix := "DBUS_SESSION_BUS_ADDRESS="

--- a/conn_test.go
+++ b/conn_test.go
@@ -5,7 +5,6 @@ import (
 	"encoding/binary"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"sync"
 	"testing"
@@ -171,7 +170,7 @@ func TestCloseBeforeSignal(t *testing.T) {
 	defer pipewriter.Close()
 	defer reader.Close()
 
-	bus, err := NewConn(rwc{Reader: reader, Writer: ioutil.Discard})
+	bus, err := NewConn(rwc{Reader: reader, Writer: io.Discard})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -743,7 +742,7 @@ func TestDisconnectCancelsConnectionContext(t *testing.T) {
 	defer pipewriter.Close()
 	defer reader.Close()
 
-	bus, err := NewConn(rwc{Reader: reader, Writer: ioutil.Discard})
+	bus, err := NewConn(rwc{Reader: reader, Writer: io.Discard})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -778,7 +777,7 @@ func TestCancellingContextClosesConnection(t *testing.T) {
 	defer pipewriter.Close()
 	defer reader.Close()
 
-	bus, err := NewConn(rwc{Reader: reader, Writer: ioutil.Discard}, WithContext(ctx))
+	bus, err := NewConn(rwc{Reader: reader, Writer: io.Discard}, WithContext(ctx))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/decoder.go
+++ b/decoder.go
@@ -370,12 +370,6 @@ func (c *stringConverter) String(b []byte) string {
 }
 
 // toString converts a byte slice to a string without allocating.
-// Starting from Go 1.20 you should use unsafe.String.
 func toString(b []byte) string {
-	var s string
-	h := (*reflect.StringHeader)(unsafe.Pointer(&s))
-	h.Data = uintptr(unsafe.Pointer(&b[0]))
-	h.Len = len(b)
-
-	return s
+	return unsafe.String(&b[0], len(b))
 }

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/godbus/dbus/v5
 
-go 1.12
+go 1.20
 
 require golang.org/x/sys v0.0.0-20220817070843-5a390386f1f2

--- a/proto_test.go
+++ b/proto_test.go
@@ -3,7 +3,7 @@ package dbus
 import (
 	"bytes"
 	"encoding/binary"
-	"io/ioutil"
+	"io"
 	"math"
 	"reflect"
 	"testing"
@@ -371,7 +371,7 @@ func BenchmarkDecodeMessageBig(b *testing.B) {
 func BenchmarkEncodeMessageSmall(b *testing.B) {
 	var err error
 	for i := 0; i < b.N; i++ {
-		err = smallMessage.EncodeTo(ioutil.Discard, binary.LittleEndian)
+		err = smallMessage.EncodeTo(io.Discard, binary.LittleEndian)
 		if err != nil {
 			b.Fatal(err)
 		}
@@ -381,7 +381,7 @@ func BenchmarkEncodeMessageSmall(b *testing.B) {
 func BenchmarkEncodeMessageBig(b *testing.B) {
 	var err error
 	for i := 0; i < b.N; i++ {
-		err = bigMessage.EncodeTo(ioutil.Discard, binary.LittleEndian)
+		err = bigMessage.EncodeTo(io.Discard, binary.LittleEndian)
 		if err != nil {
 			b.Fatal(err)
 		}

--- a/server_interfaces_test.go
+++ b/server_interfaces_test.go
@@ -1,7 +1,7 @@
 package dbus
 
 import (
-	"fmt"
+	"errors"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -83,7 +83,7 @@ func (t *tester) LookupMethod(name string) (Method, bool) {
 		return t, true
 	case "Error":
 		return terrfn(func(in string) error {
-			return fmt.Errorf(in)
+			return errors.New(in)
 		}), true
 	case "Introspect":
 		return intro_fn(func() string {

--- a/transport_nonce_tcp.go
+++ b/transport_nonce_tcp.go
@@ -5,8 +5,8 @@ package dbus
 
 import (
 	"errors"
-	"io/ioutil"
 	"net"
+	"os"
 )
 
 func init() {
@@ -28,7 +28,7 @@ func newNonceTcpTransport(keys string) (transport, error) {
 	if err != nil {
 		return nil, err
 	}
-	b, err := ioutil.ReadFile(noncefile)
+	b, err := os.ReadFile(noncefile)
 	if err != nil {
 		return nil, err
 	}

--- a/transport_nonce_tcp_test.go
+++ b/transport_nonce_tcp_test.go
@@ -2,7 +2,6 @@ package dbus
 
 import (
 	"bufio"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"testing"
@@ -38,7 +37,7 @@ func TestTcpNonceConnection(t *testing.T) {
 // startDaemon starts a dbus-daemon instance with the given config
 // and returns its address string and underlying process.
 func startDaemon(t *testing.T, config string) (string, *os.Process) {
-	cfg, err := ioutil.TempFile("", "")
+	cfg, err := os.CreateTemp("", "")
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Bump Ubuntu and FreeBSD versions used in CI, as well as the Go and golangci-lint versions. To pass the new default linter checks, this also introduces `unsafe.String` which raises the minimum Go version to 1.20 (released 1.5 years ago).