### PR TITLE
Add ConnectUnix and DialUnix

### DIFF
--- a/conn_unix.go
+++ b/conn_unix.go
@@ -4,6 +4,7 @@
 package dbus
 
 import (
+	"net"
 	"os"
 )
 
@@ -15,4 +16,29 @@ func getSystemBusPlatformAddress() string {
 		return address
 	}
 	return defaultSystemBusAddress
+}
+
+// DialUnix establishes a new private connection to the message bus specified by UnixConn.
+func DialUnix(conn *net.UnixConn, opts ...ConnOption) (*Conn, error) {
+	tr, err := newUnixTransportFromConn(conn)
+	if err != nil {
+		return nil, err
+	}
+	return newConn(tr, opts...)
+}
+
+func ConnectUnix(uconn *net.UnixConn, opts ...ConnOption) (*Conn, error) {
+	conn, err := DialUnix(uconn, opts...)
+	if err != nil {
+		return nil, err
+	}
+	if err = conn.Auth(conn.auth); err != nil {
+		_ = conn.Close()
+		return nil, err
+	}
+	if err = conn.Hello(); err != nil {
+		_ = conn.Close()
+		return nil, err
+	}
+	return conn, nil
 }

--- a/transport_unix.go
+++ b/transport_unix.go
@@ -55,6 +55,14 @@ type unixTransport struct {
 	hasUnixFDs bool
 }
 
+func newUnixTransportFromConn(conn *net.UnixConn) (transport, error) {
+	t := new(unixTransport)
+	t.UnixConn = conn
+	t.hasUnixFDs = true
+
+	return t, nil
+}
+
 func newUnixTransport(keys string) (transport, error) {
 	var err error
 


### PR DESCRIPTION
These allow creating D-Bus connections from `*net.UnixConn` on Unix systems.

File descriptors may be wrapped with
```go
func fdToUnixConn(fd dbus.UnixFD, name string) (*net.UnixConn, error) {
	c, err := net.FileConn(os.NewFile(uintptr(fd), name))
	if err != nil {
		return nil, err
	}
    return c.(*net.UnixConn), nil
}
```
and will work as well.

This also technically introduces some sort of peer-to-peer support for when only auth client is needed (i.e. QEMU).

Fixes #76
Partially fixes #384 