### PR TITLE
Documentation: Deprecate old-style functions

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -58,7 +58,7 @@ type Conn struct {
 
 // SessionBus returns a shared connection to the session bus, connecting to it
 // if not already done.
-// If you would prefer a private connection, use ConnectSessionBus.
+// If you would prefer a private connection, use [ConnectSessionBus].
 func SessionBus() (conn *Conn, err error) {
 	sessionBusLck.Lock()
 	defer sessionBusLck.Unlock()
@@ -90,7 +90,7 @@ func getSessionBusAddress(autolaunch bool) (string, error) {
 
 // SessionBusPrivate returns a new private connection to the session bus.
 //
-// Deprecated: use ConnectSessionBus instead.
+// Deprecated: use [ConnectSessionBus] instead.
 func SessionBusPrivate(opts ...ConnOption) (*Conn, error) {
 	address, err := getSessionBusAddress(true)
 	if err != nil {
@@ -113,14 +113,14 @@ func SessionBusPrivateNoAutoStartup(opts ...ConnOption) (*Conn, error) {
 
 // SessionBusPrivate returns a new private connection to the session bus.
 //
-// Deprecated: use ConnectSessionBus with options instead.
+// Deprecated: use [ConnectSessionBus] with options instead.
 func SessionBusPrivateHandler(handler Handler, signalHandler SignalHandler) (*Conn, error) {
 	return SessionBusPrivate(WithHandler(handler), WithSignalHandler(signalHandler))
 }
 
 // SystemBus returns a shared connection to the system bus, connecting to it if
 // not already done. Because the returned connection is shared, do not close the connection.
-// If you would prefer a private connection which you may close, use ConnectSystemBus.
+// If you would prefer a private connection which you may close, use [ConnectSystemBus].
 func SystemBus() (conn *Conn, err error) {
 	systemBusLck.Lock()
 	defer systemBusLck.Unlock()
@@ -175,14 +175,14 @@ func Connect(address string, opts ...ConnOption) (*Conn, error) {
 // Note: this connection is not ready to use. One must perform Auth and Hello
 // on the connection before it is usable.
 //
-// Deprecated: use ConnectSystemBus instead.
+// Deprecated: use [ConnectSystemBus] instead.
 func SystemBusPrivate(opts ...ConnOption) (*Conn, error) {
 	return Dial(getSystemBusPlatformAddress(), opts...)
 }
 
 // SystemBusPrivateHandler returns a new private connection to the system bus, using the provided handlers.
 //
-// Deprecated: use ConnectSystemBus with options instead.
+// Deprecated: use [ConnectSystemBus] with options instead.
 func SystemBusPrivateHandler(handler Handler, signalHandler SignalHandler) (*Conn, error) {
 	return SystemBusPrivate(WithHandler(handler), WithSignalHandler(signalHandler))
 }


### PR DESCRIPTION
I came here after encountering an application bug where it inadvertently closed a shared SystemBus connection. I bet a common mistake that is made after glancing through past issues.

After reviewing the library documentation and similar issues reported I decided to use the `SystemBusPrivate` function. It was mentioned in https://github.com/godbus/dbus/issues/15 and an example was given here: https://github.com/godbus/dbus/pull/140/ (`ExampleSystemBusPrivate`). I later realized that I was looking at go doc v4 documentation for the library (at pkg.go.dev) instead of the current latest v5 which include the Connect* methods introduced with https://github.com/godbus/dbus/pull/185.

Since @jsouthworth mentioned that we could deprecate the old-style methods in favor of the new Connect* ones (https://github.com/godbus/dbus/pull/185#issuecomment-561345118) I decided to help out so that others could avoid the pitfalls I came across and to make it clear which methods they should use.
