### PR TITLE
ci: bump freebsd to 14.3

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -4,8 +4,8 @@ freebsd_instance:
 
 task:
   name: Test on FreeBSD
-  install_script: pkg install -y go122 dbus
+  install_script: pkg install -y go125 dbus
   test_script: |
     /usr/local/etc/rc.d/dbus onestart && \
     eval `dbus-launch --sh-syntax` && \
-    go122 test -v ./...
+    go125 test -v ./...


### PR DESCRIPTION
This should fix the following error:

> The resource 'projects/freebsd-org-cloud-dev/global/images/family/freebsd-14-2' was not found

While at it, also bump Go version used on FreeBSD.