### PR TITLE
Fix and simplify getHomeDir

### DIFF
--- a/auth_sha1_windows.go
+++ b/auth_sha1_windows.go
@@ -102,21 +102,9 @@ func (a authCookieSha1) generateChallenge() []byte {
 	return enc
 }
 
-// Get returns the home directory of the current user, which is usually the
-// value of HOME environment variable. In case it is not set or empty, os/user
-// package is used.
-//
-// If linking statically with cgo enabled against glibc, make sure the
-// osusergo build tag is used.
-//
-// If needing to do nss lookups, do not disable cgo or set osusergo.
 func getHomeDir() string {
-	homeDir := os.Getenv("HOME")
-	if homeDir != "" {
-		return homeDir
-	}
-	if u, err := user.Current(); err == nil {
-		return u.HomeDir
+	if dir, err := os.UserHomeDir(); err == nil {
+		return dir
 	}
 	return "/"
 }


### PR DESCRIPTION
Since commits 99fac80 and ec919d8 (PR #418) it's clear that `getHomeDir` is only used on Windows.

Ironically, `$HOME` is not used on Windows (instead, it's `%USERPROFILE%`), so the code always falls back to [user.Current](https://pkg.go.dev/os/user#Current), which internally uses [os.UserHomeDir](https://pkg.go.dev/os#UserHomeDir) to fill in `HomeDir`.

So, it is both simpler and more correct to use os.UserHomeDir directly. Fall back to "/" in case of an error like the previous implementation did.