### PR TITLE
conn: support /run and /var/run default addresses

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -144,7 +144,11 @@ func ConnectSessionBus(opts ...ConnOption) (*Conn, error) {
 
 // ConnectSystemBus connects to the system bus.
 func ConnectSystemBus(opts ...ConnOption) (*Conn, error) {
-	return Connect(getSystemBusPlatformAddress(), opts...)
+	address, err := getSystemBusPlatformAddress()
+	if err != nil {
+		return nil, err
+	}
+	return Connect(address, opts...)
 }
 
 // Connect connects to the given address.
@@ -171,7 +175,11 @@ func Connect(address string, opts ...ConnOption) (*Conn, error) {
 // Note: this connection is not ready to use. One must perform Auth and Hello
 // on the connection before it is usable.
 func SystemBusPrivate(opts ...ConnOption) (*Conn, error) {
-	return Dial(getSystemBusPlatformAddress(), opts...)
+	address, err := getSystemBusPlatformAddress()
+	if err != nil {
+		return nil, err
+	}
+	return Dial(address, opts...)
 }
 
 // SystemBusPrivateHandler returns a new private connection to the system bus, using the provided handlers.

--- a/conn_darwin.go
+++ b/conn_darwin.go
@@ -23,12 +23,12 @@ func getSessionBusPlatformAddress() (string, error) {
 	return "unix:path=" + string(b[:len(b)-1]), nil
 }
 
-func getSystemBusPlatformAddress() string {
+func getSystemBusPlatformAddress() (string, error) {
 	address := os.Getenv("DBUS_LAUNCHD_SESSION_BUS_SOCKET")
 	if address != "" {
 		return fmt.Sprintf("unix:path=%s", address)
 	}
-	return defaultSystemBusAddress
+	return defaultSystemBusAddress, nil
 }
 
 func tryDiscoverDbusSessionBusAddress() string {

--- a/conn_unix.go
+++ b/conn_unix.go
@@ -3,18 +3,27 @@
 package dbus
 
 import (
+	"errors"
 	"net"
 	"os"
 )
 
-const defaultSystemBusAddress = "unix:path=/var/run/dbus/system_bus_socket"
+var defaultSystemBusPaths = []string{
+	"/var/run/dbus/system_bus_socket",
+	"/run/dbus/system_bus_socket",
+}
 
-func getSystemBusPlatformAddress() string {
+func getSystemBusPlatformAddress() (string, error) {
 	address := os.Getenv("DBUS_SYSTEM_BUS_ADDRESS")
 	if address != "" {
-		return address
+		return address, nil
 	}
-	return defaultSystemBusAddress
+	for _, path := range defaultSystemBusPaths {
+		if _, err := os.Stat(path); err == nil {
+			return "unix:path=" + path, nil
+		}
+	}
+	return "", errors.New("system bus not found")
 }
 
 // DialUnix establishes a new private connection to the message bus specified by UnixConn.

--- a/conn_windows.go
+++ b/conn_windows.go
@@ -4,10 +4,10 @@ import "os"
 
 const defaultSystemBusAddress = "tcp:host=127.0.0.1,port=12434"
 
-func getSystemBusPlatformAddress() string {
+func getSystemBusPlatformAddress() (string, error) {
 	address := os.Getenv("DBUS_SYSTEM_BUS_ADDRESS")
 	if address != "" {
 		return address
 	}
-	return defaultSystemBusAddress
+	return defaultSystemBusAddress, nil
 }


### PR DESCRIPTION
`/var/run` has been depreciated for a while and some Linux filesystem layouts no longer include the backwards-compatibility link from `/var/run` to `/run`.

This changes Linux's `getSystemBusPlatformAddress` to probe for the system bus address in `/var/run` followed by in `/run`. This maintains compatibility with distributions where `/run` and `/var/run` are different (very rare) and somehow have two system buses (!) while also supporting distributions where `/var/run` is not linked.

References:
 - [dbus: Use ${runstatedir} for system bus instead of ${localstatedir}/run](https://gitlab.freedesktop.org/dbus/dbus/-/issues/180)
 - [gdbus: gdbusaddress: Use runstatedir rather than localstatedir](https://gitlab.gnome.org/GNOME/glib/-/commit/b7b9f89417ab547b96dc5000ef5c6be9d0a307d5)

Fixes: #423