### PR TITLE
Drop ununsed import in windows specific code

### DIFF
--- a/auth_sha1_windows.go
+++ b/auth_sha1_windows.go
@@ -7,7 +7,6 @@ import (
 	"crypto/sha1"
 	"encoding/hex"
 	"os"
-	"os/user"
 )
 
 // AuthCookieSha1 returns an Auth that authenticates as the given user with the


### PR DESCRIPTION
in https://github.com/godbus/dbus/commit/d3fc3b583895e27c3337f77ea7134b0a81159955 the usage of `user.Current()` was dropped, but the corresponding import was left `"os/user"`

found in kubernetes CI jobs:
- https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/ci-kubernetes-unit-dependencies/2002303465103036416
- https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/ci-kubernetes-e2e-kind-dependencies/2002337439577804800

confirmed fix by running https://github.com/dims/typecheck
```
❯ typecheck
type-checking windows/arm64
type-checking darwin/arm64
ERROR(windows/arm64): /Users/dsrinivas/go/src/github.com/godbus/dbus/auth_sha1_windows.go:10:2: "os/user" imported and not used
type-checking windows/386
type-checking linux/amd64
ERROR(windows/386): /Users/dsrinivas/go/src/github.com/godbus/dbus/auth_sha1_windows.go:10:2: "os/user" imported and not used
type-checking windows/amd64
ERROR(windows/amd64): /Users/dsrinivas/go/src/github.com/godbus/dbus/auth_sha1_windows.go:10:2: "os/user" imported and not used
type-checking linux/arm
type-checking linux/386
type-checking linux/ppc64le
type-checking linux/arm64
type-checking linux/s390x
type-checking darwin/amd64
```

cc @kolyshkin 