### PR TITLE
Switch from reflect.Ptr to reflect.Pointer

### DIFF
--- a/dbus.go
+++ b/dbus.go
@@ -60,7 +60,7 @@ func storeInterfaces(src, dest any) error {
 }
 
 func store(dest, src reflect.Value) error {
-	if dest.Kind() == reflect.Ptr {
+	if dest.Kind() == reflect.Pointer {
 		if dest.IsNil() {
 			dest.Set(reflect.New(dest.Type().Elem()))
 		}
@@ -119,7 +119,7 @@ func isConvertibleTo(dest, src reflect.Type) bool {
 	case dest.Kind() == reflect.Slice:
 		return src.Kind() == reflect.Slice &&
 			isConvertibleTo(dest.Elem(), src.Elem())
-	case dest.Kind() == reflect.Ptr:
+	case dest.Kind() == reflect.Pointer:
 		dest = dest.Elem()
 		return isConvertibleTo(dest, src)
 	case dest.Kind() == reflect.Struct:
@@ -358,7 +358,7 @@ func alignment(t reflect.Type) int {
 		return 4
 	case reflect.Uint64, reflect.Int64, reflect.Float64, reflect.Struct:
 		return 8
-	case reflect.Ptr:
+	case reflect.Pointer:
 		return alignment(t.Elem())
 	}
 	return 1

--- a/encoder.go
+++ b/encoder.go
@@ -148,7 +148,7 @@ func (enc *encoder) encode(v reflect.Value, depth int) {
 			panic(err)
 		}
 		enc.pos += n
-	case reflect.Ptr:
+	case reflect.Pointer:
 		enc.encode(v.Elem(), depth)
 	case reflect.Slice, reflect.Array:
 		// Lookahead offset: 4 bytes for uint32 length (with alignment),

--- a/sig.go
+++ b/sig.go
@@ -81,7 +81,7 @@ func getSignature(t reflect.Type, depth *depthCounter) (sig string) {
 		return "t"
 	case reflect.Float64:
 		return "d"
-	case reflect.Ptr:
+	case reflect.Pointer:
 		return getSignature(t.Elem(), depth)
 	case reflect.String:
 		if t == objectPathType {


### PR DESCRIPTION
Go 1.18 renamed reflect.Ptr to reflect.Pointer (see [1]). Convert our usage accordingly.

[1]: https://go.dev/doc/go1.18#reflectpkgreflect