### PR TITLE
README: update

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-![Build Status](https://github.com/godbus/dbus/workflows/Go/badge.svg)
-
 dbus
 ----
 
@@ -12,20 +10,12 @@ D-Bus message bus system.
 * Go-like API (channels for signals / asynchronous method calls, Goroutine-safe connections)
 * Subpackages that help with the introspection / property interfaces
 
-### Installation
-
-This packages requires Go 1.20 or later. It can be installed by running the command below:
-
-```
-go get github.com/godbus/dbus/v5
-```
-
 ### Usage
 
 The complete package documentation and some simple examples are available at
 [pkg.go.dev](https://pkg.go.dev/github.com/godbus/dbus/v5). Also, the
-[_examples](https://github.com/godbus/dbus/tree/master/_examples) directory
-gives a short overview over the basic usage. 
+[\_examples](https://github.com/godbus/dbus/tree/master/_examples) directory
+gives a short overview over the basic usage.
 
 #### Projects using godbus
 - [fyne](https://github.com/fyne-io/fyne) a cross platform GUI in Go inspired by Material Design.
@@ -41,7 +31,7 @@ further notice.
 
 ### License
 
-go.dbus is available under the Simplified BSD License; see LICENSE for the full
+The library is available under the Simplified BSD License; see LICENSE for the full
 text.
 
-Nearly all of the credit for this library goes to github.com/guelfey/go.dbus.
+Nearly all of the credit for this library goes to https://github.com/guelfey.

--- a/README.md
+++ b/README.md
@@ -18,13 +18,11 @@ The complete package documentation and some simple examples are available at
 gives a short overview over the basic usage.
 
 #### Projects using godbus
-- [fyne](https://github.com/fyne-io/fyne) a cross platform GUI in Go inspired by Material Design.
-- [fynedesk](https://github.com/fyne-io/fynedesk) a full desktop environment for Linux/Unix using Fyne.
-- [go-bluetooth](https://github.com/muka/go-bluetooth) provides a bluetooth client over bluez dbus API.
-- [iwd](https://github.com/shibumi/iwd) go bindings for the internet wireless daemon "iwd".
+- [bluetooth](https://github.com/tinygo-org/bluetooth): cross-platform Bluetooth API for Go and TinyGo.
+- [fyne](https://github.com/fyne-io/fyne): a cross platform GUI in Go inspired by Material Design.
+- [fynedesk](https://github.com/fyne-io/fynedesk): a full desktop environment for Linux/Unix using Fyne.
+- [go-systemd](https://github.com/coreos/go-systemd): Go bindings to systemd.
 - [notify](https://github.com/esiqveland/notify) provides desktop notifications over dbus into a library.
-- [playerbm](https://github.com/altdesktop/playerbm) a bookmark utility for media players.
-- [rpic](https://github.com/stephenhu/rpic) lightweight web app and RESTful API for managing a Raspberry Pi
 
 Please note that the API is considered unstable for now and may change without
 further notice.


### PR DESCRIPTION
1. Remove the build status badge (it's not working).

2. Remove the Installation section (installation is obvious to any Go developer, and the Go version requirement can be seen in go.mod).

3. Escape the _ in the link (so my Vim shows the rest of the file correctly).

4. Remove the (wrong) library name from the License section.

5. Fix the URL to give credit to @guelfey.

6. Refresh the "Projects using godbus" section (see the second commit).

The resulting github's rendering of README.md can be seen [here](https://github.com/kolyshkin/dbus/tree/readme?tab=readme-ov-file#dbus).