### PR TITLE
feat: expose unreferenced Unix FDs from replies

### DIFF
--- a/call.go
+++ b/call.go
@@ -21,6 +21,10 @@ type Call struct {
 	// Holds the response once the call is done.
 	Body []any
 
+	// UnixFDs holds file descriptors received with the response message,
+	// including descriptors that are not referenced by Body.
+	UnixFDs []UnixFD
+
 	// ResponseSequence stores the sequence number of the DBus message containing
 	// the call response (or error). This can be compared to the sequence number
 	// of other call responses and signals on this connection to determine their

--- a/conn.go
+++ b/conn.go
@@ -936,7 +936,7 @@ func (tracker *callTracker) handleReply(sequence Sequence, msg *Message) uint32 
 	_, ok := tracker.calls[serial]
 	tracker.lck.RUnlock()
 	if ok {
-		tracker.finalizeWithBody(serial, sequence, msg.Body)
+		tracker.finalizeWithReply(serial, sequence, msg.Body, msg.fds)
 	}
 	return serial
 }
@@ -965,7 +965,7 @@ func (tracker *callTracker) handleSendError(msg *Message, err error) {
 	}
 }
 
-func (tracker *callTracker) finalizeWithBody(sn uint32, sequence Sequence, body []any) {
+func (tracker *callTracker) finalizeWithReply(sn uint32, sequence Sequence, body []any, unixFDs []int) {
 	tracker.lck.Lock()
 	c, ok := tracker.calls[sn]
 	if ok {
@@ -974,6 +974,10 @@ func (tracker *callTracker) finalizeWithBody(sn uint32, sequence Sequence, body 
 	tracker.lck.Unlock()
 	if ok {
 		c.Body = body
+		c.UnixFDs = make([]UnixFD, len(unixFDs))
+		for i, fd := range unixFDs {
+			c.UnixFDs[i] = UnixFD(fd)
+		}
 		c.ResponseSequence = sequence
 		c.done()
 	}

--- a/message.go
+++ b/message.go
@@ -111,6 +111,7 @@ type Message struct {
 	Body    []any
 
 	serial uint32
+	fds    []int
 }
 
 type header struct {

--- a/transport_unix.go
+++ b/transport_unix.go
@@ -206,6 +206,7 @@ func (t *unixTransport) ReadMessage() (*Message, error) {
 		if err != nil {
 			return nil, err
 		}
+		msg.fds = fds
 		dec.Reset(r, order, fds)
 		if err = decodeMessageBody(msg, dec); err != nil {
 			return nil, err


### PR DESCRIPTION
I ran into this with tpm2-abrmd. Since tpm2-abrmd 2.4.1, `CreateConnection` returns only the connection id in the D-Bus reply body and sends the communication FD via the reply's Unix FD list: https://github.com/tpm2-software/tpm2-abrmd/commit/7d5a73dd879a9fc4280f4d39a80496f1c8d23ad1

`godbus` already receives those FDs in the Unix transport, but callers cannot access them unless the reply body references them through `h`. This change exposes FDs received with method replies via `UnixFDs` field. Existing `h` decoding behavior is unchanged.

```
$ busctl --system introspect com.intel.tss2.Tabrmd /com/intel/tss2/Tabrmd/Tcti com.intel.tss2.TctiTabrmd 

NAME              TYPE   SIGNATURE RESULT/VALUE FLAGS
.Cancel           method t         u            -    
.CreateConnection method -         t            -    
.SetLocality      method ty        u            -    
```

