### PR TITLE
mediakeys.go example: Fix error handling.

### DIFF
--- a/_examples/mediakeys.go
+++ b/_examples/mediakeys.go
@@ -26,7 +26,7 @@ func main() {
 	bus := conn.Object("org.gnome.SettingsDaemon", "/org/gnome/SettingsDaemon/MediaKeys")
 	call := bus.Call("org.gnome.SettingsDaemon.MediaKeys.GrabMediaPlayerKeys", 0, "test app", uint(0))
 	if call.Err != nil {
-		panic(err)
+		panic(call.Err)
 	}
 
 	signals := make(chan *dbus.Signal, 10)


### PR DESCRIPTION
The panic re-uses the `err` variable defined in line 11 and at this point guaranteed to be nil - instead of using the call.Err just checked by the if. This change fixes that problem.